### PR TITLE
This are some enhance feature for erpc multi-processor.

### DIFF
--- a/erpc_c/port/erpc_port_mqx.cpp
+++ b/erpc_c/port/erpc_port_mqx.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "erpc_port.h"
+#include <new>
+#include "mqx.h"
+
+#if __cplusplus >= 201103
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif // NOEXCEPT
+
+#if !(__embedded_cplusplus)
+using namespace std;
+#endif
+
+#if defined(__CC_ARM) /* Keil MDK */
+void *operator new(std::size_t count) throw(std::bad_alloc)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new(std::size_t count, const std::nothrow_t &tag) throw()
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new[](std::size_t count) throw(std::bad_alloc)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new[](std::size_t count, const std::nothrow_t &tag) throw()
+
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void operator delete(void *ptr) throw()
+{
+    erpc_free(ptr);
+}
+
+void operator delete[](void *ptr) throw()
+{
+    erpc_free(ptr);
+}
+
+#else
+
+void *operator new(size_t count)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new(size_t count, const nothrow_t &tag)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new[](size_t count)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void *operator new[](size_t count, const nothrow_t &tag)
+{
+    void *p = erpc_malloc(count);
+    return p;
+}
+
+void operator delete(void *ptr)
+{
+    erpc_free(ptr);
+}
+
+void operator delete[](void *ptr)
+{
+    erpc_free(ptr);
+}
+#endif
+
+void *erpc_malloc(size_t size)
+{
+    void *p = _mem_alloc_system(size);
+    return p;
+}
+
+void erpc_free(void *ptr)
+{
+    _mem_free(ptr);
+}
+
+/* Provide function for pure virtual call to avoid huge demangling code being linked in ARM GCC */
+#if ((defined(__GNUC__)) && (defined(__arm__)))
+extern "C" void __cxa_pure_virtual()
+{
+    while (1)
+        ;
+}
+#endif

--- a/erpc_c/setup/erpc_client_setup.cpp
+++ b/erpc_c/setup/erpc_client_setup.cpp
@@ -31,8 +31,6 @@
 #include "client_manager.h"
 #include "manually_constructed.h"
 #include "basic_codec.h"
-#include "message_buffer.h"
-#include "erpc_config_internal.h"
 #include "erpc_setup.h"
 #include <new>
 #include <assert.h>

--- a/erpc_c/setup/erpc_server_setup.cpp
+++ b/erpc_c/setup/erpc_server_setup.cpp
@@ -33,6 +33,7 @@
 #include "basic_codec.h"
 #include "message_buffer.h"
 #include "erpc_config_internal.h"
+#include "erpc_setup.h"
 #include <new>
 #include <assert.h>
 
@@ -46,24 +47,6 @@ using namespace erpc;
 // Classes
 ////////////////////////////////////////////////////////////////////////////////
 
-class BasicMessageBufferFactory : public MessageBufferFactory
-{
-public:
-    virtual MessageBuffer create()
-    {
-        uint8_t *buf = new (nothrow) uint8_t[ERPC_DEFAULT_BUFFER_SIZE];
-        return MessageBuffer(buf, ERPC_DEFAULT_BUFFER_SIZE);
-    }
-
-    virtual void dispose(MessageBuffer *buf)
-    {
-        assert(buf);
-        if (*buf)
-        {
-            delete[] buf->get();
-        }
-    }
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Variables

--- a/erpc_c/setup/erpc_server_setup.cpp
+++ b/erpc_c/setup/erpc_server_setup.cpp
@@ -31,8 +31,6 @@
 #include "simple_server.h"
 #include "manually_constructed.h"
 #include "basic_codec.h"
-#include "message_buffer.h"
-#include "erpc_config_internal.h"
 #include "erpc_setup.h"
 #include <new>
 #include <assert.h>

--- a/erpc_c/setup/erpc_setup.h
+++ b/erpc_c/setup/erpc_setup.h
@@ -64,4 +64,4 @@ public:
 
 /*! @} */
 
-#endif
+#endif //_EMBEDDED_RPC_SETUP_H_

--- a/erpc_c/setup/erpc_setup.h
+++ b/erpc_c/setup/erpc_setup.h
@@ -31,6 +31,8 @@
 #define _EMBEDDED_RPC_SETUP_H_
 #include <new>
 #include <assert.h>
+#include "erpc_config_internal.h"
+#include "message_buffer.h"
 
 #if !(__embedded_cplusplus)
 using namespace std;
@@ -62,4 +64,4 @@ public:
 
 /*! @} */
 
-#endif // _EMBEDDED_RPC__CLIENT_SETUP_H_
+#endif

--- a/erpc_c/setup/erpc_setup.h
+++ b/erpc_c/setup/erpc_setup.h
@@ -29,6 +29,7 @@
 
 #ifndef _EMBEDDED_RPC_SETUP_H_
 #define _EMBEDDED_RPC_SETUP_H_
+
 #include <new>
 #include <assert.h>
 #include "erpc_config_internal.h"
@@ -41,7 +42,7 @@ using namespace std;
 using namespace erpc;
 
 ////////////////////////////////////////////////////////////////////////////////
-// CLASS
+// Classes
 ////////////////////////////////////////////////////////////////////////////////
 class BasicMessageBufferFactory : public MessageBufferFactory
 {

--- a/erpc_c/transports/dspi_slave_transport.cpp
+++ b/erpc_c/transports/dspi_slave_transport.cpp
@@ -57,13 +57,13 @@ DspiSlaveTransport::DspiSlaveTransport(SPI_Type *spiBaseAddr, uint32_t baudRate,
 : m_spiBaseAddr(spiBaseAddr)
 , m_baudRate(baudRate)
 , m_srcClock_Hz(srcClock_Hz)
-, m_binited(false)
+, m_isInited(false)
 {
 }
 
 DspiSlaveTransport::~DspiSlaveTransport()
 {
-    if(m_binited)
+    if (m_isInited)
     {
       GPIO_ClearPinsOutput(ERPC_BOARD_DSPI_INT_GPIO, 1U << ERPC_BOARD_DSPI_INT_PIN);
     }
@@ -85,7 +85,7 @@ status_t DspiSlaveTransport::init()
     
     GPIO_PinInit(ERPC_BOARD_DSPI_INT_GPIO, ERPC_BOARD_DSPI_INT_PIN, &gpioConfig);
     
-    m_binited = true;
+    m_isInited = true;
     return kErpcStatus_Success;
 }
 

--- a/erpc_c/transports/dspi_slave_transport.cpp
+++ b/erpc_c/transports/dspi_slave_transport.cpp
@@ -57,11 +57,16 @@ DspiSlaveTransport::DspiSlaveTransport(SPI_Type *spiBaseAddr, uint32_t baudRate,
 : m_spiBaseAddr(spiBaseAddr)
 , m_baudRate(baudRate)
 , m_srcClock_Hz(srcClock_Hz)
+, m_binited(false)
 {
 }
 
 DspiSlaveTransport::~DspiSlaveTransport()
 {
+    if(m_binited)
+    {
+      GPIO_ClearPinsOutput(ERPC_BOARD_DSPI_INT_GPIO, 1U << ERPC_BOARD_DSPI_INT_PIN);
+    }
     DSPI_Deinit(m_spiBaseAddr);
 }
 
@@ -80,6 +85,7 @@ status_t DspiSlaveTransport::init()
     
     GPIO_PinInit(ERPC_BOARD_DSPI_INT_GPIO, ERPC_BOARD_DSPI_INT_PIN, &gpioConfig);
     
+    m_binited = true;
     return kErpcStatus_Success;
 }
 

--- a/erpc_c/transports/dspi_slave_transport.cpp
+++ b/erpc_c/transports/dspi_slave_transport.cpp
@@ -106,7 +106,7 @@ status_t DspiSlaveTransport::underlyingReceive(uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
+    
     return status;
 }
 
@@ -127,6 +127,6 @@ status_t DspiSlaveTransport::underlyingSend(const uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
+    
     return status;
 }

--- a/erpc_c/transports/dspi_slave_transport.cpp
+++ b/erpc_c/transports/dspi_slave_transport.cpp
@@ -106,7 +106,7 @@ status_t DspiSlaveTransport::underlyingReceive(uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    
+    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
     return status;
 }
 
@@ -127,6 +127,6 @@ status_t DspiSlaveTransport::underlyingSend(const uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    
+    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
     return status;
 }

--- a/erpc_c/transports/dspi_slave_transport.h
+++ b/erpc_c/transports/dspi_slave_transport.h
@@ -68,6 +68,7 @@ protected:
     SPI_Type *m_spiBaseAddr; /*!< Base address of DSPI peripheral used in this transport layer */
     uint32_t m_baudRate;       /*!< Baud rate of DSPI peripheral used in this transport layer */
     uint32_t m_srcClock_Hz;    /*!< Source clock of DSPI peripheral used in this transport layer */
+    bool m_binited;
 
 private:
     /*!

--- a/erpc_c/transports/dspi_slave_transport.h
+++ b/erpc_c/transports/dspi_slave_transport.h
@@ -68,7 +68,7 @@ protected:
     SPI_Type *m_spiBaseAddr; /*!< Base address of DSPI peripheral used in this transport layer */
     uint32_t m_baudRate;       /*!< Baud rate of DSPI peripheral used in this transport layer */
     uint32_t m_srcClock_Hz;    /*!< Source clock of DSPI peripheral used in this transport layer */
-    bool m_binited;           /*!< the SPI peripheral init status flag */
+    bool m_isInited;           /*!< the SPI peripheral init status flag */
 
 private:
     /*!

--- a/erpc_c/transports/dspi_slave_transport.h
+++ b/erpc_c/transports/dspi_slave_transport.h
@@ -68,7 +68,7 @@ protected:
     SPI_Type *m_spiBaseAddr; /*!< Base address of DSPI peripheral used in this transport layer */
     uint32_t m_baudRate;       /*!< Baud rate of DSPI peripheral used in this transport layer */
     uint32_t m_srcClock_Hz;    /*!< Source clock of DSPI peripheral used in this transport layer */
-    bool m_binited;
+    bool m_binited;           /*!< the SPI peripheral init status flag */
 
 private:
     /*!

--- a/erpc_c/transports/spi_slave_transport.cpp
+++ b/erpc_c/transports/spi_slave_transport.cpp
@@ -99,7 +99,7 @@ status_t SpiSlaveTransport::underlyingReceive(uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
+    
     return status;
 }
 
@@ -119,6 +119,6 @@ status_t SpiSlaveTransport::underlyingSend(const uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
+    
     return status;
 }

--- a/erpc_c/transports/spi_slave_transport.cpp
+++ b/erpc_c/transports/spi_slave_transport.cpp
@@ -99,7 +99,7 @@ status_t SpiSlaveTransport::underlyingReceive(uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    
+    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
     return status;
 }
 
@@ -119,6 +119,6 @@ status_t SpiSlaveTransport::underlyingSend(const uint8_t *data, uint32_t size)
     while (!s_isTransferCompleted)
     {
     }
-    
+    GPIO_SetPinsOutput(ERPC_BOARD_SPI_INT_GPIO, 1U << ERPC_BOARD_SPI_INT_PIN);
     return status;
 }

--- a/erpc_c/transports/spi_slave_transport.cpp
+++ b/erpc_c/transports/spi_slave_transport.cpp
@@ -57,11 +57,16 @@ SpiSlaveTransport::SpiSlaveTransport(SPI_Type *spiBaseAddr, uint32_t baudRate, u
 : m_spiBaseAddr(spiBaseAddr)
 , m_baudRate(baudRate)
 , m_srcClock_Hz(srcClock_Hz)
+, m_isInited(false)
 {
 }
 
 SpiSlaveTransport::~SpiSlaveTransport()
 {
+    if (m_isInited)
+    {
+      GPIO_ClearPinsOutput(ERPC_BOARD_DSPI_INT_GPIO, 1U << ERPC_BOARD_DSPI_INT_PIN);
+    }
     SPI_Deinit(m_spiBaseAddr);
 }
 
@@ -79,7 +84,7 @@ status_t SpiSlaveTransport::init()
     gpioConfig.outputLogic = 1U;
     
     GPIO_PinInit(ERPC_BOARD_SPI_INT_GPIO, ERPC_BOARD_SPI_INT_PIN, &gpioConfig);
-    
+    m_isInited = true;
     return kErpcStatus_Success;
 }
 

--- a/erpc_c/transports/spi_slave_transport.h
+++ b/erpc_c/transports/spi_slave_transport.h
@@ -69,6 +69,7 @@ protected:
     SPI_Type *m_spiBaseAddr; /*!< Base address of SPI peripheral used in this transport layer */
     uint32_t m_baudRate;       /*!< Baud rate of SPI peripheral used in this transport layer */
     uint32_t m_srcClock_Hz;    /*!< Source clock of SPI peripheral used in this transport layer */
+    bool m_isInited;           /*!< the SPI peripheral init status flag */
 
 private:
     /*!


### PR DESCRIPTION
1. move the common code out to erpc_setup.h
2. when the salve spi is destroyed, we need make the master able to finish the transmission, otherwise the master will be in deadloop if slave is destroyed unexpectedly
3. add porting for mqx, just for information. for porting to any RTOS,
the transport need rewrite and the porting folder files need to be take care 