### PR TITLE
Fixed bug affecting uninitialized incomingAddressLength variable. Thi…

### DIFF
--- a/erpc_c/transports/erpc_tcp_transport.cpp
+++ b/erpc_c/transports/erpc_tcp_transport.cpp
@@ -323,7 +323,7 @@ void TCPTransport::serverThread(void)
     while (m_runServer)
     {
         struct sockaddr incomingAddress;
-        socklen_t incomingAddressLength;
+        socklen_t incomingAddressLength = sizeof(struct sockaddr);
         int incomingSocket = accept(serverSocket, &incomingAddress, &incomingAddressLength);
         if (incomingSocket > 0)
         {


### PR DESCRIPTION
Fixed bug affecting uninitialized incomingAddressLength variable. This will manifest with changes to the stack for example by adding local variables to serverThread() in tcp_transport.cpp. See: https://stackoverflow.com/questions/886782/c-sockets-raises-error-code-22-einval-invalid-argument for more details