### PR TITLE
Updated erpc_python/setup.py

### DIFF
--- a/erpc_python/setup.py
+++ b/erpc_python/setup.py
@@ -36,6 +36,7 @@ from setuptools import setup
 from codecs import open
 from os import path
 
+ERPC_VERSION = None
 here = path.abspath(path.dirname(__file__))
 
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:

--- a/erpc_python/setup.py
+++ b/erpc_python/setup.py
@@ -33,7 +33,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from setuptools import setup
-from erpc import erpc_version
 from codecs import open
 from os import path
 
@@ -42,6 +41,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+with open(path.join(here, 'erpc', 'erpc_version.py')) as f:
+    exec(f.read())
+
 #steps: https://packaging.python.org/distributing/
 #source distribution: python setup.py sdist
 #wheel distribution: python setup.py bdist_wheel
@@ -49,7 +51,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name="erpc",
-    version=erpc_version.ERPC_VERSION,
+    version=ERPC_VERSION,
     description="eRPC Python infrastructure",
     long_description=long_description,
     author="NXP",


### PR DESCRIPTION
## Description
Updated `erpc_python/setup.py`. Remove import of the `erpc_version` submodule, causing execution of the package initialization script, pulling another submodules and in consequence causing failure of package installation in a clean Python environment. Instead of using `import` feature, open the `erpc_version.py` file directly in execute it, causing `ERPC_VERSION` constant to be available directly in the namespace when `setup` function is being executed.

## Related Issue
Resolves #37 