### PR TITLE
Remove whitespace from C common header template

### DIFF
--- a/erpcgen/src/templates/c_common_header.template
+++ b/erpcgen/src/templates/c_common_header.template
@@ -129,7 +129,7 @@ extern "C" {
 {$> fn.mlComment}
 {$fn.prototype};{$fn.ilComment}{$loop.addNewLineIfNotLast}
 {%  endfor -- functions %}
-//@} {$iface.ilComment}
+//@}{$iface.ilComment}
 {% endfor -- iface %}
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Removes whitespace from the C common header template.  This whitespace
separates the template's doxygen-style comment and the user's
(optional) trailing interface comment.

This helps remove undesirable trailing whitespace for the (many) users
that don't use trailing interface comments.

Signed-off-by: Chris Ring <cring@ti.com>