### PR TITLE
Fixed union free function by always adding all union type cases.

### DIFF
--- a/erpcgen/src/CGenerator.cpp
+++ b/erpcgen/src/CGenerator.cpp
@@ -2725,8 +2725,6 @@ data_map CGenerator::getEncodeDecodeCall(const string &name, Group *group, DataT
                     data_map caseData;
                     caseData["name"] = unionCase->getCaseName();
                     caseData["value"] = unionCase->getCaseValue();
-                    // if current case need call free function, default false
-                    caseData["needCaseFreeingCall"] = false;
                     data_list caseMembers;
                     data_map memberData;
                     data_map caseMembersFree;
@@ -2758,8 +2756,6 @@ data_map CGenerator::getEncodeDecodeCall(const string &name, Group *group, DataT
                             {
                                 // set freeing function for current union
                                 templateData["freeingCall"] = m_templateData["freeUnion"];
-                                // current case need free memory
-                                caseData["needCaseFreeingCall"] = true;
                                 // current member need free memory
                                 memberData["isNeedFreeingCall"] = true;
                             }

--- a/erpcgen/src/templates/c_common_functions.template
+++ b/erpcgen/src/templates/c_common_functions.template
@@ -396,24 +396,22 @@ for (uint32_t {$info.forLoopCount} = 0; {$info.forLoopCount} < {$info.size}; ++{
 switch ({$info.dataLiteral}{$info.discriminatorName})
 {
 {% for case in info.cases %}
-{%  if case.needCaseFreeingCall == true %}
-{%   if case.name == "default" %}
+{%  if case.name == "default" %}
     default:
-{%   else %}
+{%  else %}
     case {% if case.name != "" %}{$case.name}{% else %}{$case.value}{% endif %}:
-{%   endif -- default or case %}
+{%  endif -- default or case %}
     {
-{%   for member in case.members %}
-{%    if member.isNeedFreeingCall %}
+{%  for member in case.members %}
+{%   if member.isNeedFreeingCall %}
 {$addIndent("        ", member.coderCall.freeingCall(member.coderCall))}
-{%    endif %}
-{%    if empty(member.coderCall.memberAllocation) == false %}
+{%   endif %}
+{%   if empty(member.coderCall.memberAllocation) == false %}
 {$addIndent("        ", member.coderCall.freeingCall2(member.coderCall))}
-{%    endif%}
-{%   endfor -- members %}
+{%   endif%}
+{%  endfor -- members %}
         break;
     }
-{%  endif %}
 {% endfor -- cases %}
 }
 {% enddef ------------------------------- freeUnion %}


### PR DESCRIPTION
See #69.

Fixed the issue by adding all cases to the switch statement even if there are empty.

This fixes the issue because if now a free statement is needed in the default case it is only called if it's none of the other cases.
