### PR TITLE
Add deinit function for rpmsg tty transport.

### DIFF
--- a/erpc_c/setup/erpc_setup_rpmsg_tty_rtos_remote.cpp
+++ b/erpc_c/setup/erpc_setup_rpmsg_tty_rtos_remote.cpp
@@ -35,3 +35,8 @@ erpc_transport_t erpc_transport_rpmsg_lite_tty_rtos_remote_init(unsigned long sr
     }
     return NULL;
 }
+
+void erpc_transport_rpmsg_lite_tty_rtos_deinit()
+{
+    s_transport.destroy();
+}

--- a/erpc_c/setup/erpc_transport_setup.h
+++ b/erpc_c/setup/erpc_transport_setup.h
@@ -44,8 +44,8 @@ extern "C" {
 /*!
  * @brief Create a CMSIS UART transport.
  *
- * Create a CMSIS UART transport instance, to be used on both the server 
- * and the client side. 
+ * Create a CMSIS UART transport instance, to be used on both the server
+ * and the client side.
  *
  * @param[in] uartDrv CMSIS USART driver structure address (Driver Control Block).
  *
@@ -60,7 +60,7 @@ erpc_transport_t erpc_transport_cmsis_uart_init(void *uartDrv);
 /*!
  * @brief Create a host PC serial port transport.
  *
- * Create a host PC serial port transport instance. 
+ * Create a host PC serial port transport instance.
  *
  * @param[in] portName Port name.
  * @param[in] baudRate Baud rate.
@@ -76,7 +76,7 @@ erpc_transport_t erpc_transport_serial_init(const char *portName, long baudRate)
 /*!
  * @brief Create a SPI master transport.
  *
- * Create SPI master transport instance, to be used at master core. 
+ * Create SPI master transport instance, to be used at master core.
  *
  * @param[in] baseAddr Base address of SPI peripheral used in this transport layer.
  * @param[in] baudRate SPI baud rate.
@@ -89,7 +89,7 @@ erpc_transport_t erpc_transport_spi_master_init(void *baseAddr, uint32_t baudRat
 /*!
  * @brief Create a SPI slave transport.
  *
- * Create SPI slave transport instance, to be used at slave core. 
+ * Create SPI slave transport instance, to be used at slave core.
  *
  * @param[in] baseAddr Base address of SPI peripheral used in this transport layer.
  * @param[in] baudRate SPI baud rate.
@@ -106,7 +106,7 @@ erpc_transport_t erpc_transport_spi_slave_init(void *baseAddr, uint32_t baudRate
 /*!
  * @brief Create a DSPI master transport.
  *
- * Create DSPI master transport instance, to be used at master core. 
+ * Create DSPI master transport instance, to be used at master core.
  *
  * @param[in] baseAddr Base address of DSPI peripheral used in this transport layer.
  * @param[in] baudRate DSPI baud rate.
@@ -119,7 +119,7 @@ erpc_transport_t erpc_transport_dspi_master_init(void *baseAddr, uint32_t baudRa
 /*!
  * @brief Create a DSPI slave transport.
  *
- * Create DSPI slave transport instance, to be used at slave core. 
+ * Create DSPI slave transport instance, to be used at slave core.
  *
  * @param[in] baseAddr Base address of DSPI peripheral used in this transport layer.
  * @param[in] baudRate DSPI baud rate.
@@ -136,8 +136,8 @@ erpc_transport_t erpc_transport_dspi_slave_init(void *baseAddr, uint32_t baudRat
 /*!
  * @brief Create an MU transport.
  *
- * Create Messaging Unit (MU) transport instance, to be used on both the server 
- * and the client side. Base address of the MU peripheral needs to be passed. 
+ * Create Messaging Unit (MU) transport instance, to be used on both the server
+ * and the client side. Base address of the MU peripheral needs to be passed.
  *
  * @param[in] baseAddr Base address of MU peripheral.
  *
@@ -246,6 +246,13 @@ erpc_transport_t erpc_transport_rpmsg_lite_rtos_remote_init(unsigned long src_ad
 erpc_transport_t erpc_transport_rpmsg_lite_tty_rtos_remote_init(unsigned long src_addr, unsigned long dst_addr,
                                                                 void *start_address, int rpmsg_link_id,
                                                                 rpmsg_ready_cb ready, char *nameservice_name);
+
+/*!
+ * @brief Deinitialize an RPMSG lite tty rtos transport.
+ *
+ * This function deinitializes the RPMSG lite tty rtos transport.
+ */
+void erpc_transport_rpmsg_lite_tty_rtos_deinit(void);
 //@}
 
 //! @name Linux RPMSG endpoint setup

--- a/erpc_c/transports/erpc_rpmsg_tty_rtos_transport.cpp
+++ b/erpc_c/transports/erpc_rpmsg_tty_rtos_transport.cpp
@@ -37,12 +37,31 @@ RPMsgTTYRTOSTransport::RPMsgTTYRTOSTransport(void)
 
 RPMsgTTYRTOSTransport::~RPMsgTTYRTOSTransport(void)
 {
-    if (m_rpmsg_ept != RL_NULL)
+    if (s_rpmsg != NULL)
     {
-        rpmsg_queue_destroy(s_rpmsg, m_rpmsg_ept)
+        if (m_rpmsg_ept != RL_NULL)
+        {
+            if (RL_SUCCESS != rpmsg_lite_destroy_ept(s_rpmsg, m_rpmsg_ept))
+            {
+                return;
+            }
+        }
+
+        if (m_rpmsg_queue != RL_NULL)
+        {
+            if (RL_SUCCESS != rpmsg_queue_destroy(s_rpmsg, m_rpmsg_queue))
+            {
+                return;
+            }
+        }
+
+        if (RL_SUCCESS != rpmsg_lite_deinit(s_rpmsg))
+        {
+            return;
+        }
+
+        s_initialized = 0;
     }
-    rpmsg_lite_deinit(s_rpmsg);
-    s_initialized = 0;
 }
 
 void RPMsgTTYRTOSTransport::setCrc16(Crc16 *crcImpl)

--- a/erpc_c/transports/erpc_rpmsg_tty_rtos_transport.cpp
+++ b/erpc_c/transports/erpc_rpmsg_tty_rtos_transport.cpp
@@ -37,6 +37,10 @@ RPMsgTTYRTOSTransport::RPMsgTTYRTOSTransport(void)
 
 RPMsgTTYRTOSTransport::~RPMsgTTYRTOSTransport(void)
 {
+    if (m_rpmsg_ept != RL_NULL)
+    {
+        rpmsg_queue_destroy(s_rpmsg, m_rpmsg_ept)
+    }
     rpmsg_lite_deinit(s_rpmsg);
     s_initialized = 0;
 }


### PR DESCRIPTION
This function adds deinit function for RPMSG LITE TTY transport. @MichalPrincNXP could you provide feedback please. Is it ok to deinitialize master/remote tty RPMSG instance like this?