### PR TITLE
Freeing services in server causing hardfault issue for staticli alloc…

### DIFF
--- a/erpc_c/infra/erpc_simple_server.cpp
+++ b/erpc_c/infra/erpc_simple_server.cpp
@@ -17,12 +17,6 @@ using namespace erpc;
 
 SimpleServer::~SimpleServer(void)
 {
-    while (m_firstService != NULL)
-    {
-        Service *firstService = m_firstService;
-        m_firstService = m_firstService->getNext();
-        delete firstService;
-    }
 }
 
 void SimpleServer::disposeBufferAndCodec(Codec *codec)


### PR DESCRIPTION
This issue is in eRPC for longer time. Works only for dynamicly allocated services. Wrong place for freeing memory. Services should generated also freeing function which can users call when they need.