### PR TITLE
Mismatch between C++ and Python for callback index type

### DIFF
--- a/erpcgen/src/templates/py_coders.template
+++ b/erpcgen/src/templates/py_coders.template
@@ -80,7 +80,7 @@ codec.start_write_union({$self}discriminator)
 {#--------------- function ---------------#}
 {% elif info.type == "function" %}
 {%  if info.tableName != "" %}
-{$codec}.write_int32({$ info.tableName}.index({$name})){%>%}
+{$codec}.write_int8({$ info.tableName}.index({$name})){%>%}
 {%  else %}
 # When are defined less than 2 callback functions, eRPC don't need serialize any code.
 {%  endif%}
@@ -171,7 +171,7 @@ _n{$depth} = {$codec}.start_read_list()
 {#--------------- function ---------------#}
 {% elif info.type == "function" %}
 {%  if info.tableName != "" %}
-{$name} = {$ info.tableName}[{$codec}.read_int32()]
+{$name} = {$ info.tableName}[{$codec}.read_int8()]
 {%  else %}
 # When are defined less than 2 callback functions, eRPC don't need serialize any code.
 {$indent}{$name} = {$info.callbackName}


### PR DESCRIPTION
In eRPC, when multiple callbacks are defined, callbacks are stored
in an array on both the client and server. When a callback is register,
only the index of the callback in this array is sent over the transport.
In C++, the array index is encoded as a unit8, where as in Python it is
encoded as a uint32. So, a Python client will not be aligned with a C++
server, leading to wrong information being decoded by the server. This
fix aligns both to be a uint8 type for the callback index.