### PR TITLE
Fix Python template bugs on union discriminator and reference

### DIFF
--- a/erpcgen/src/templates/py_coders.template
+++ b/erpcgen/src/templates/py_coders.template
@@ -102,7 +102,7 @@ codec.start_write_union({$self}{$info.discriminatorName})
 {%  else %}
 {%   set self = "self." %}
 {%  endif %}
-{$self}discriminator = codec.start_read_union()
+{$self}{$info.discriminatorName} = codec.start_read_union()
 {%  if self == "self." %}
 {$indent}{$name} = {$name}_union()
 {% endif %}

--- a/erpcgen/src/templates/py_common.template
+++ b/erpcgen/src/templates/py_common.template
@@ -105,11 +105,11 @@ class {$s.name}(object):
         if {$self_m_name} is None:
             raise ValueError("{$m.name} is None")
 {%    if (m.type.type == 'union' && m.type.isNonEncapsulatedUnion == true) %}
-        {$m.name}._write(codec, self.{$m.discriminator})
+        self.{$m.name}._write(codec, self.{$m.discriminator})
 {%    else -- isNonEncapsulatedUnion %}
         {$encodeValue(m.type, self_m_name, "codec", "        ", 0)}
 {%    endif -- isNonEncapsulatedUnion %}
-{%   endif -- isNullable %}
+{%  endif -- isNullable %}
 {% endfor -- members %}
 
     def __str__(self):


### PR DESCRIPTION
Fix Python codec template bugs related to unions. Both encoder
and decoder were emitting a literal 'discriminator' instead
of de-referencing this data structure member for the actual
discriminator symbol name. In class method template, use object
scope instead of global scope to invoke the write() method of
a non-encapsulated union member.