### PR TITLE
deadlock on arbitrated + TCP transport changes

### DIFF
--- a/erpc_c/infra/erpc_manually_constructed.h
+++ b/erpc_c/infra/erpc_manually_constructed.h
@@ -91,6 +91,12 @@ public:
     {
         new (m_storage) T(a1, a2, a3, a4, a5);
     }
+	
+    template <typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
+    void construct(const A1 &a1, const A2 &a2, const A3 &a3, const A4 &a4, const A5 &a5, const A6 &a6)
+    {
+        new (m_storage) T(a1, a2, a3, a4, a5, a6);
+    }
     //@}
 
     /*!

--- a/erpc_c/infra/erpc_transport_arbitrator.cpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.cpp
@@ -56,9 +56,20 @@ erpc_status_t TransportArbitrator::receive(MessageBuffer *message)
         erpc_status_t err = m_sharedTransport->receive(message);
         if (err)
         {
+			// if we timeout, we must unblock all pending client(s)	
+			if (err == kErpcStatus_Timeout)
+			{	
+				PendingClientInfo *client = m_clientList;
+				for (; client; client = client->m_next)
+				{
+					if (client->m_isValid)
+					{
+						client->m_sem.put();
+					}	
+				}
+			}
             return err;
         }
-
         m_codec->setBuffer(*message);
 
         // Parse the message header.

--- a/erpc_c/port/erpc_threading_freertos.cpp
+++ b/erpc_c/port/erpc_threading_freertos.cpp
@@ -175,7 +175,7 @@ void Thread::threadEntryPointStub(void *arg)
 Mutex::Mutex(void)
 : m_mutex(0)
 {
-    m_mutex = xSemaphoreCreateMutex();
+    m_mutex = xSemaphoreCreateRecursiveMutex();
 }
 
 Mutex::~Mutex(void)

--- a/erpc_c/setup/erpc_setup_tcp.cpp
+++ b/erpc_c/setup/erpc_setup_tcp.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 (c) Sierra Wireless
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "erpc_manually_constructed.h"
+#include "erpc_transport_setup.h"
+#include "erpc_tcp_transport.h"
+
+using namespace erpc;
+
+////////////////////////////////////////////////////////////////////////////////
+// Variables
+////////////////////////////////////////////////////////////////////////////////
+
+static ManuallyConstructed<TCPTransport> s_transport;
+
+////////////////////////////////////////////////////////////////////////////////
+// Code
+////////////////////////////////////////////////////////////////////////////////
+
+erpc_transport_t erpc_transport_tcp_init_full(const char *host, uint16_t port, bool isServer)
+{
+    s_transport.construct(host, port, isServer);
+    if (kErpcStatus_Success == s_transport->open()) 
+	{
+        return reinterpret_cast<erpc_transport_t>(s_transport.get());
+	}	
+	return NULL;	
+}
+
+erpc_transport_t erpc_transport_tcp_init(bool isServer)
+{
+    s_transport.construct(isServer);
+    return reinterpret_cast<erpc_transport_t>(s_transport.get());
+}
+
+bool erpc_transport_tcp_open(void)
+{
+    return s_transport.get()->open() == kErpcStatus_Success;
+}
+
+void erpc_transport_tcp_close(void)
+{
+    s_transport.get()->close(true);
+}
+
+void erpc_transport_tcp_configure(const char *host, uint16_t port)
+{
+	s_transport.get()->configure(host, port);
+}
+

--- a/erpc_c/setup/erpc_transport_setup.h
+++ b/erpc_c/setup/erpc_transport_setup.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 //! @name Transport setup
 //@{
@@ -282,6 +283,67 @@ erpc_transport_t erpc_transport_rpmsg_linux_init(int16_t local_addr, int8_t type
 void erpc_transport_rpmsg_linux_deinit(void);
 //@}
 
+//! @name TCP transport setup
+//@{
+	
+/*!
+ * @brief Create and open TCP transport
+ *
+ * For server, create a TCP listen socket and wait for connections
+ * For client, connect to server
+ *
+ * @param[in] host hostname/IP address to listen on or server to connect to
+ * @param[in] port port to listen on or server to connect to
+ * @param[in] isServer true if we are a server
+ *
+ * @return Return NULL or erpc_transport_t instance pointer.
+ */
+erpc_transport_t erpc_transport_tcp_init_full(const char *host, uint16_t port, bool isServer);
+
+/*!
+ * @brief Create and configure TCP transport but do not open anything
+ *
+ * Parameters are simply memorized to be used with further init() and open()
+ *
+ * @param[in] host hostname/IP address to listen on or server to connect to
+ * @param[in] port port to listen on or server to connect to
+ *
+ */
+void erpc_transport_tcp_configure(const char *host, uint16_t port);
+
+/*!
+ * @brief Create a TCP transport
+ *
+ * Simply create transport instance, don't start anything
+ * @param[in] isServer true if we are a server
+ *
+ * @return Return NULL or erpc_transport_t instance pointer.
+ */
+erpc_transport_t erpc_transport_tcp_init(bool isServer);
+
+/*!
+ * @brief Open TCP connection
+ *
+ * For server, create a TCP listen socket and wait for connections
+ * For client, connect to server
+ *
+ * @return Return TRUE if listen/connection successful
+ */
+bool erpc_transport_tcp_open(void);
+
+/*!
+ * @brief Close TCP connection
+ *
+ * For server, stop listening and close all sockets. Note that the server mode 
+ * uses and accept() which is a not-recommended blocking method so we can't exit
+ * until a connection attempts is made. This is a deadlock but assuming that TCP
+ * code is supposed to be for test, I assume it's acceptable. Otherwise a non-blocking
+ * socket or select() shoudl be used 
+ * For client, close server connection
+ *
+ * @return Return TRUE if listen/connection successful
+ */
+void erpc_transport_tcp_close(void);
 //@}
 
 #ifdef __cplusplus

--- a/erpc_c/transports/erpc_tcp_transport.h
+++ b/erpc_c/transports/erpc_tcp_transport.h
@@ -76,9 +76,10 @@ public:
     /*!
      * @brief This function disconnects client or stop server host.
      *
+	 * @param[in] stopServer Specify is server shall be closed as well (stop listen())
      * @retval #kErpcStatus_Success Always return this.
      */
-    virtual erpc_status_t close(void);
+    virtual erpc_status_t close(bool stopServer);
 
 protected:
     bool m_isServer;       /*!< If true then server is using transport, else client. */

--- a/erpc_c/transports/erpc_tcp_transport.h
+++ b/erpc_c/transports/erpc_tcp_transport.h
@@ -79,7 +79,7 @@ public:
 	 * @param[in] stopServer Specify is server shall be closed as well (stop listen())
      * @retval #kErpcStatus_Success Always return this.
      */
-    virtual erpc_status_t close(bool stopServer);
+    virtual erpc_status_t close(bool stopServer = true);
 
 protected:
     bool m_isServer;       /*!< If true then server is using transport, else client. */


### PR DESCRIPTION
I have done a port on another platform but I assume you are not really interested by that. During that, I've made a few changes that you might be interested in. 

- fix the deadlock in arbitrated reference here https://github.com/EmbeddedRPC/erpc/issues/93 by simply using the PHY layer timeout
- some proposal on arbitrated for TCP as well where I think the client should not respond by success when the server is not connected. It created another deadlock