### PR TITLE
string type with no malloc (WiP for discussion)

### DIFF
--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -109,8 +109,8 @@ void BasicCodec::writePtr(uintptr_t value)
 
 void BasicCodec::writeString(uint32_t length, const char *value)
 {
-    // Just treat the string as binary.
-    writeBinary(length, reinterpret_cast<const uint8_t *>(value));
+    // Just treat the string as binary but add trailing NULL.
+    writeBinary(length + 1, reinterpret_cast<const uint8_t *>(value));
 }
 
 void BasicCodec::writeBinary(uint32_t length, const uint8_t *value)

--- a/erpcgen/src/CGenerator.cpp
+++ b/erpcgen/src/CGenerator.cpp
@@ -2258,11 +2258,9 @@ void CGenerator::getEncodeDecodeBuiltin(Group *group, BuiltinType *t, data_map &
 
     if (t->isString())
     {
+        templateData["zeroCopy"] = findAnnotation(structMember, DIRECT_ANNOTATION) && !findAnnotation(structMember, RETAIN_ANNOTATION);
         templateData["checkStringNull"] = false;
-        templateData["withoutAlloc"] = ((structMember->getDirection() == kInoutDirection) ||
-                                        (structType && group->getSymbolDirections(structType).count(kInoutDirection))) ?
-                                           true :
-                                           false;
+
         if (!isFunctionParam)
         {
             templateData["stringAllocSize"] = getOutputName(structMember) + "_len";
@@ -2280,10 +2278,6 @@ void CGenerator::getEncodeDecodeBuiltin(Group *group, BuiltinType *t, data_map &
                 templateData["checkStringNull"] = true;
                 templateData["stringLocalName"] = getOutputName(structMember);
                 templateData["stringAllocSize"] = getAnnStringValue(structMember, MAX_LENGTH_ANNOTATION);
-                if (structMember->getDirection() == kInoutDirection || structMember->getDirection() == kOutDirection)
-                {
-                    templateData["withoutAlloc"] = true;
-                }
 
                 if (templateData["stringAllocSize"]->getvalue() == "")
                 {

--- a/erpcgen/src/annotations.h
+++ b/erpcgen/src/annotations.h
@@ -67,6 +67,9 @@
 //! Do not free memory for a parameter in the server shim.
 #define RETAIN_ANNOTATION "retain"
 
+//! Do not alloc memory for a parameter in the server shim, just pass the pointer in the received buffer
+#define DIRECT_ANNOTATION "direct"
+
 //! Data handled through shared memory area
 #define SHARED_ANNOTATION "shared"
 

--- a/erpcgen/src/templates/c_coders.template
+++ b/erpcgen/src/templates/c_coders.template
@@ -1,24 +1,31 @@
 {% def decodeBuiltinType(info) --------------- BuiltinType %}
 {% if info.builtinType == "kStringType" %}
 uint32_t {$info.stringLocalName}_len;
+{%  if (source == "server" && info.zeroCopy) %}
+codec->readString(&{$info.stringLocalName}_len, (char**) &{$info.stringLocalName});
+{%  else %}
 char * {$info.stringLocalName}_local;
 codec->readString(&{$info.stringLocalName}_len, &{$info.stringLocalName}_local);
-{%  if ((source == "client" && info.withoutAlloc == false) or source == "server") %}
-{$info.name} = (char *) erpc_malloc(({$info.stringAllocSize} + 1) * sizeof(char));
-{%   if generateAllocErrorChecks == true %}
+{%   if source == "server" && !info.zeroCopy %}
+{$info.name} = ({$info.builtinTypeName}) erpc_malloc(({$info.stringAllocSize} + 1) * sizeof(char));
+{%    if generateAllocErrorChecks == true %}
 if ({$info.name} == NULL)
 {
     codec->updateStatus(kErpcStatus_MemoryError);
 }
 else
 {
-{%   endif -- generateAllocErrorChecks == true %}
-{%  endif -- withoutAlloc %}
-{%  if (((source == "client" && info.withoutAlloc == false) or source == "server") && generateAllocErrorChecks == true) %}    {%  endif -- withoutAlloc %}memcpy({$info.name}, {$info.stringLocalName}_local, {$info.stringLocalName}_len);
-{%  if (((source == "client" && info.withoutAlloc == false) or source == "server") && generateAllocErrorChecks == true) %}    {%  endif -- withoutAlloc %}({$info.name})[{$info.stringLocalName}_len] = 0;
-{%  if (((source == "client" && info.withoutAlloc == false) or source == "server") && generateAllocErrorChecks == true) %}
+{%    endif -- generateAllocErrorChecks == true %}
+    memcpy({$info.name}, {$info.stringLocalName}_local, {$info.stringLocalName}_len);
+    ({$info.name})[{$info.stringLocalName}_len] = 0;
+{%    if generateAllocErrorChecks == true %}
 }
-{%  endif -- withoutAlloc && generateAllocErrorChecks %}
+{%    endif -- generateAllocErrorChecks %}
+{%   else %}
+memcpy({$info.name}, {$info.stringLocalName}_local, {$info.stringLocalName}_len);
+({$info.name})[{$info.stringLocalName}_len] = 0;
+{%   endif -- server && zeroCopy %}
+{%  endif -- server && !zeroCopy %}
 {% else %}
 {%  if source == "client" && info.pointerScalarTypes %}
 codec->read({$info.name});
@@ -232,7 +239,11 @@ codec->readData({$info.name}, {$info.sizeTemp} * sizeof({$info.builtinTypeName})
 {# Encode sending data #}
 {% def encodeBuiltinType(info) -----------------  %}
 {% if info.builtinType == "kStringType" %}
-codec->writeString(strlen({$info.name}), {$info.name});
+{%  if source == "client" && info.zeroCopy %}
+codec->writeString(strlen((char*){$info.name}), (char*){$info.name});
+{% else %}
+codec->writeBinary(strlen((char*){$info.name}), (uint8_t*){$info.name});
+{%  endif -- zeroCopy %}
 {% else %}
 {%  if source == "client" && info.pointerScalarTypes %}
 codec->write(*{$info.name});

--- a/erpcgen/src/templates/c_common_functions.template
+++ b/erpcgen/src/templates/c_common_functions.template
@@ -354,10 +354,12 @@ else
 
 {# ---------------- freeData ---------------- #}
 {% def freeData(info) %}
+{% if !info.zeroCopy %}
 if ({$info.freeName})
 {
     erpc_free({$info.freeName});
 }
+{% endif %}
 {% enddef ------------------------------- freeData %}
 
 {# ---------------- freeStruct ---------------- #}


### PR DESCRIPTION
Hi - while I was tweaking my eRPC use, I needed to find a solution to send a few really large strings. Increasing the default buffer size does not seem to be a good idea, but before looking for a solution, I realized that the server shim does a malloc and a copy no matter what of any received string. 

Using malloc is usually not great and I was wondering if there a reason for not using pointers inside transport buffer. Of course, there are cases where it's no desirable for memory isolation, but was there a reason beyond that?

This PR, that is just for discussion, tries to add an annotation \@direct which, when used, allows the client shim to send the string with the NULL byte so that the server shim can pass directly a pointer inside the received buffer. When \@direct is not used, code should be generated as usual

Let me know what you think.