### PR TITLE
paranoid-2: Allow to compile code with paranoid compiler flags -Wall -Wextra -Wshadow -Werror -pedantic-errors

### DIFF
--- a/erpc_c/infra/erpc_simple_server.cpp
+++ b/erpc_c/infra/erpc_simple_server.cpp
@@ -178,7 +178,7 @@ erpc_status_t SimpleServer::run(RequestContext &request)
         uint32_t methodId;
         uint32_t sequence;
 
-        erpc_status_t err = runInternalBegin(&codec, buff, msgType, serviceId, methodId, sequence);
+        err = runInternalBegin(&codec, buff, msgType, serviceId, methodId, sequence);
 
         if (err)
         {


### PR DESCRIPTION
infra/erpc_simple_server.cpp: fix declaration of ‘err’ shadows a prev…ious local

erpc_simple_server.cpp: In member function ‘virtual erpc_status_t erpc::SimpleServer::run(erpc::RequestContext&)’:
erpc_simple_server.cpp:181:23: error: declaration of ‘err’ shadows a previous local [-Werror=shadow]
         erpc_status_t err = runInternalBegin(&codec, buff, msgType, serviceId, methodId, sequence);
                       ^~~
erpc_simple_server.cpp:169:19: note: shadowed declaration is here
     erpc_status_t err = kErpcStatus_Success;
                   ^~~