### PR TITLE
erpc_framed_transport.cpp: return error if received message has zero length

### DIFF
--- a/erpc_c/infra/erpc_framed_transport.cpp
+++ b/erpc_c/infra/erpc_framed_transport.cpp
@@ -53,6 +53,12 @@ erpc_status_t FramedTransport::receive(MessageBuffer *message)
             return ret;
         }
 
+        // received size can't be zero.
+        if (h.m_messageSize == 0)
+        {
+            return kErpcStatus_ReceiveFailed;
+        }
+
         // received size can't be larger then buffer length.
         if (h.m_messageSize > message->getLength())
         {


### PR DESCRIPTION
This was spotted on a SAML21 controller:
#0  usart_sync_read (io_descr=0x200006dc <USART_0>, buf=0x20000378 <s_msgFactory+8> , length=0) at ../hal/src/hal_usart_sync.c:271
#1  0x000001e0 in io_read (io_descr=0x200006dc <USART_0>, buf=0x20000378 <s_msgFactory+8> , length=0) at ../hal/src/hal_io.c:62
#2  0x0000e3da in erpc::UsartSyncTransport::underlyingReceive (this=0x20000578 <s_transport>, data=0x20000378 <s_msgFactory+8> , size=0) at ../erpc_usart_sync_transport.cpp:29
#3  0x0000dd96 in erpc::FramedTransport::receive (this=0x20000578 <s_transport>, message=0x200026c4) at ../erpc_framed_transport.cpp:63
#4  0x0000d7da in erpc::SimpleServer::runInternalBegin (this=0x20000340 <s_server>, codec=0x200026c0, buff=..., msgType=@0x200026bf: 32, serviceId=@0x200026b8: 536880832, methodId=@0x200026b4: 536871784, sequence=@0x200026b0: 536871784) at ../erpc_simple_server.cpp:64
#5  0x0000d72a in erpc::SimpleServer::runInternal (this=0x20000340 <s_server>) at ../erpc_simple_server.cpp:42
#6  0x0000d99e in erpc::SimpleServer::poll (this=0x20000340 <s_server>) at ../erpc_simple_server.cpp:223
#7  0x0000d44e in erpc_server_poll () at ../erpc_server_setup.cpp:97
#8  0x00006fa4 in main () at ../main.c:72

The UART need to be restarted to recover from a such error, for ex.:
    if (erpc_server_poll()) {
        usart_sync_disable(&USART_0);
        usart_sync_enable(&USART_0);
    }