### PR TITLE
Fix compiler error multiple definitions of `g_client'

### DIFF
--- a/erpc_c/setup/erpc_arbitrated_client_setup.cpp
+++ b/erpc_c/setup/erpc_arbitrated_client_setup.cpp
@@ -30,7 +30,7 @@ using namespace erpc;
 
 // global client variables
 static ManuallyConstructed<ArbitratedClientManager> s_client;
-ClientManager *g_client = NULL;
+extern ClientManager *g_client;
 
 static ManuallyConstructed<BasicCodecFactory> s_codecFactory;
 static ManuallyConstructed<TransportArbitrator> s_arbitrator;


### PR DESCRIPTION
Symbol g_client (ClientManager) is defined twice as global symbol