### PR TITLE
transport arbitrator: override Transport::hasMessage

### DIFF
--- a/erpc_c/infra/erpc_transport_arbitrator.cpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.cpp
@@ -48,6 +48,11 @@ void TransportArbitrator::setCrc16(Crc16 *crcImpl)
     m_sharedTransport->setCrc16(crcImpl);
 }
 
+bool TransportArbitrator::hasMessage(void)
+{
+    return m_sharedTransport->hasMessage();
+}
+
 erpc_status_t TransportArbitrator::receive(MessageBuffer *message)
 {
     assert(m_sharedTransport && "shared transport is not set");

--- a/erpc_c/infra/erpc_transport_arbitrator.cpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.cpp
@@ -50,6 +50,8 @@ void TransportArbitrator::setCrc16(Crc16 *crcImpl)
 
 bool TransportArbitrator::hasMessage(void)
 {
+    assert(m_sharedTransport && "shared transport is not set");
+
     return m_sharedTransport->hasMessage();
 }
 

--- a/erpc_c/infra/erpc_transport_arbitrator.h
+++ b/erpc_c/infra/erpc_transport_arbitrator.h
@@ -97,6 +97,14 @@ public:
      */
     virtual void setCrc16(Crc16 *crcImpl);
 
+    /*!
+     * @brief Check if the underlying shared transport has a message
+     *
+     * @retval The underlying transport is expected to return true when a message is available to
+     *         process and false otherwise.
+     */
+    virtual bool hasMessage(void);
+
 protected:
     Transport *m_sharedTransport; //!< Transport being shared through this arbitrator.
     Codec *m_codec;               //!< Codec used to read incoming message headers.


### PR DESCRIPTION
Override the default implementation of hasMessage from Transport with a
version that calls through to the hasMessage of the shared transport
that the transport arbitrator is using.