### PR TITLE
Re-implement EnumMember::hasValue()

### DIFF
--- a/erpcgen/src/types/EnumMember.h
+++ b/erpcgen/src/types/EnumMember.h
@@ -37,6 +37,7 @@ public:
     EnumMember(const Token &tok, uint32_t value)
     : Symbol(kEnumMemberSymbol, tok)
     , m_value(value)
+    , m_valueSet(true)
     {
     }
 
@@ -50,6 +51,7 @@ public:
     EnumMember(const Token &tok)
     : Symbol(kEnumMemberSymbol, tok)
     , m_value(-1)
+    , m_valueSet(false)
     {
     }
 
@@ -58,7 +60,10 @@ public:
      *
      * @param[in] value Value of enum member.
      */
-    void setValue(IntegerValue value) { m_value = value; }
+    void setValue(IntegerValue value) {
+        m_value = value;
+        m_valueSet = true;
+    }
 
     /*!
      * @brief This function returns enum member value.
@@ -73,7 +78,7 @@ public:
      * @retval true When enum member has set value.
      * @retval false When enum member has not set value.
      */
-    bool hasValue() const { return -1 != (int32_t)m_value.getValue(); }
+    bool hasValue() const { return m_valueSet; }
 
     /*!
      * @brief This function returns description about the enum member.
@@ -93,6 +98,7 @@ public:
 
 protected:
     IntegerValue m_value; /*!< Integer value of enum member. */
+    bool m_valueSet;
 };
 
 } // namespace erpcgen


### PR DESCRIPTION
Issue #41 describes a problem where an enum value of -1 causes a failure
of an assertion in erpcgen. The new version of hasValue uses a bool
member variable to track when the value is set rather than using a
sentinel value of -1.