### PR TITLE
Disable free-nonheap-object warnings

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -28,7 +28,7 @@ else
     MARCH ?=    # -m32 or -m64
 endif
 
-CXXFLAGS += -std=gnu++11 -D LINUX -Wunused-variable -Wno-deprecated-register -Wno-narrowing -Werror $(MARCH)
+CXXFLAGS += -std=gnu++11 -D LINUX -Wunused-variable -Wno-deprecated-register -Wno-narrowing -Wno-free-nonheap-object -Werror $(MARCH)
 #CXXFLAGS += -Wall -Wextra -Wshadow -pedantic-errors
 CFLAGS   += -std=gnu11 -D LINUX -D _GNU_SOURCE -Werror $(MARCH)
 YYFLAGS  += -Wno-other # --debug --verbose


### PR DESCRIPTION
Without disabling this warning, g++ 11.1.0 emits this warning:
  /project/erpc/Debug/Linux/erpcsniffer/obj/erpcgen_parser.tab.cpp: In function ‘int yyparse(erpcgen::ErpcLexer*, erpcgen::AstNode**)’:
  /project/erpc/Debug/Linux/erpcsniffer/obj/erpcgen_parser.tab.cpp:3810:18: error: ‘void free(void*)’ called on unallocated object ‘yyssa’ [-Werror=free-nonheap-object]
   3810 |     YYSTACK_FREE (yyss);
  /project/erpc/Debug/Linux/erpcsniffer/obj/erpcgen_parser.tab.cpp:2025:16: note: declared here
   2025 |     yy_state_t yyssa[YYINITDEPTH];
        |                ^~~~~
  cc1plus: all warnings being treated as errors

Since -Werror is also enabled, this prevents erpcsniffer from building.

Background on false positives relating to this warning:
  https://www.mail-archive.com/help-bison@gnu.org/msg04296.html
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54202