### PR TITLE
Build TCP transport setup code into liberpc

### DIFF
--- a/erpc_c/Makefile
+++ b/erpc_c/Makefile
@@ -70,6 +70,7 @@ SOURCES += 	$(ERPC_C_ROOT)/infra/erpc_arbitrated_client_manager.cpp \
 			$(ERPC_C_ROOT)/setup/erpc_setup_mbf_static.cpp \
 			$(ERPC_C_ROOT)/setup/erpc_server_setup.cpp \
 			$(ERPC_C_ROOT)/setup/erpc_setup_serial.cpp \
+			$(ERPC_C_ROOT)/setup/erpc_setup_tcp.cpp \
 			$(ERPC_C_ROOT)/transports/erpc_inter_thread_buffer_transport.cpp \
 			$(ERPC_C_ROOT)/transports/erpc_serial_transport.cpp \
 			$(ERPC_C_ROOT)/transports/erpc_tcp_transport.cpp


### PR DESCRIPTION
The TCP transport is already included in liberpc, so it makes sense to
include the necessary setup code to use that transport from C.