### PR TITLE
Fix multiple definitions of g_client error

### DIFF
--- a/erpc_c/setup/erpc_arbitrated_client_setup.cpp
+++ b/erpc_c/setup/erpc_arbitrated_client_setup.cpp
@@ -32,8 +32,8 @@ using namespace erpc;
 
 // global client variables
 static ManuallyConstructed<ArbitratedClientManager> s_client;
-#pragma weak g_client
 ClientManager *g_client;
+#pragma weak g_client
 
 static ManuallyConstructed<BasicCodecFactory> s_codecFactory;
 static ManuallyConstructed<TransportArbitrator> s_arbitrator;

--- a/erpc_c/setup/erpc_arbitrated_client_setup.cpp
+++ b/erpc_c/setup/erpc_arbitrated_client_setup.cpp
@@ -32,8 +32,8 @@ using namespace erpc;
 
 // global client variables
 static ManuallyConstructed<ArbitratedClientManager> s_client;
-extern ClientManager *g_client;
-ClientManager *g_client = NULL;
+#pragma weak g_client
+ClientManager *g_client;
 
 static ManuallyConstructed<BasicCodecFactory> s_codecFactory;
 static ManuallyConstructed<TransportArbitrator> s_arbitrator;

--- a/erpc_c/setup/erpc_client_setup.cpp
+++ b/erpc_c/setup/erpc_client_setup.cpp
@@ -30,8 +30,8 @@ using namespace erpc;
 
 // global client variables
 static ManuallyConstructed<ClientManager> s_client;
-extern ClientManager *g_client;
-ClientManager *g_client = NULL;
+#pragma weak g_client
+ClientManager *g_client;
 static ManuallyConstructed<BasicCodecFactory> s_codecFactory;
 static ManuallyConstructed<Crc16> s_crc16;
 

--- a/erpc_c/setup/erpc_client_setup.cpp
+++ b/erpc_c/setup/erpc_client_setup.cpp
@@ -30,8 +30,8 @@ using namespace erpc;
 
 // global client variables
 static ManuallyConstructed<ClientManager> s_client;
-#pragma weak g_client
 ClientManager *g_client;
+#pragma weak g_client
 static ManuallyConstructed<BasicCodecFactory> s_codecFactory;
 static ManuallyConstructed<Crc16> s_crc16;
 


### PR DESCRIPTION
The global variable g_client was defined in both erpc_client_setup.cpp
and erpc_arbitrated_client_setup.cpp. As a result, linker errors were
produced when trying to build eRPC with both files. This change defines
the g_client in a single new place (erpc_setup_globals.cpp).

Resolves: #113