### PR TITLE
Pr multiple idl files

### DIFF
--- a/erpcgen/src/erpcgen.cpp
+++ b/erpcgen/src/erpcgen.cpp
@@ -293,31 +293,34 @@ public:
                 throw runtime_error("no input file provided");
             }
 
-            m_ErpcFile = m_positionalArgs[0].c_str();
-            if (!m_outputFilePath)
+            for (const string &idlFile : m_positionalArgs)
             {
-                m_outputFilePath = "";
-            }
+                m_ErpcFile = idlFile.c_str();
+                if (!m_outputFilePath)
+                {
+                    m_outputFilePath = "";
+                }
 
-            // Parse and build definition model.
-            InterfaceDefinition def;
-            def.parse(m_ErpcFile);
+                // Parse and build definition model.
+                InterfaceDefinition def;
+                def.parse(m_ErpcFile);
 
-            // Check for duplicate function IDs
-            UniqueIdChecker uniqueIdCheck;
-            uniqueIdCheck.makeIdsUnique(def);
+                // Check for duplicate function IDs
+                UniqueIdChecker uniqueIdCheck;
+                uniqueIdCheck.makeIdsUnique(def);
 
-            boost::filesystem::path filePath(m_ErpcFile);
-            def.setProgramInfo(filePath.filename().generic_string(), m_outputFilePath, m_codec);
+                boost::filesystem::path filePath(m_ErpcFile);
+                def.setProgramInfo(filePath.filename().generic_string(), m_outputFilePath, m_codec);
 
-            switch (m_outputLanguage)
-            {
-                case kCLanguage:
-                    CGenerator(&def).generate();
-                    break;
-                case kPythonLanguage:
-                    PythonGenerator(&def).generate();
-                    break;
+                switch (m_outputLanguage)
+                {
+                    case kCLanguage:
+                        CGenerator(&def).generate();
+                        break;
+                    case kPythonLanguage:
+                        PythonGenerator(&def).generate();
+                        break;
+                }
             }
         }
         catch (exception &e)

--- a/erpcgen/src/templates/c_common_header.template
+++ b/erpcgen/src/templates/c_common_header.template
@@ -32,8 +32,8 @@
 {$>checkCrc()}
 {% endif -- not commonTypesFile %}
 {% if commonTypesFile == "" %}
-#if !defined(ERPC_TYPE_DEFINITIONS)
-#define ERPC_TYPE_DEFINITIONS
+#if !defined(ERPC_{$outputFilename}_TYPE_DEFINITIONS)
+#define ERPC_{$outputFilename}_TYPE_DEFINITIONS
 {% if not empty(enums) %}
 
 // Enumerators data types declarations
@@ -102,7 +102,7 @@ extern const {$c.typeAndName};{$c.ilComment}{$loop.addNewLineIfNotLast}
 {%  endfor -- consts %}
 {% endif -- consts %}
 
-#endif // ERPC_TYPE_DEFINITIONS
+#endif // ERPC_{$outputFilename}_TYPE_DEFINITIONS
 {% endif -- commonTypesFile %}
 
 {% if not genCommonTypesFile %}


### PR DESCRIPTION
When trying to add a second `.erpc` IDL file into our project, we found two problems.

1) When trying to include two `*_server.h` header files, the same `#ifndef/#define ERPC_TYPE_DEFINITIONS/#endif` was used to guard the definition of different types.  As a result, the types enclosed in this `#ifndef` in the second header file included were being hidden.  The solution I came up with was to put the filename of the IDL file into the `#ifdef`.

2) The help information for erpcgen indicated that it supported passing multiple `.erpc` files, but the implementation only processed the first file.  I added a change to loop over all files passed to erpcgen.  I believe this is necessary because if `erpcgen` is invoked once per `.erpc` file, it seems that the service IDs are re-used.