### PR TITLE
Fix memset past end of buffer in erpc_setup_mbf_static.cpp

### DIFF
--- a/erpc_c/setup/erpc_setup_mbf_static.cpp
+++ b/erpc_c/setup/erpc_setup_mbf_static.cpp
@@ -43,7 +43,7 @@ public:
     : m_semaphore(1)
 #endif
     {
-        (void)memset(m_freeBufferBitmap, 0xff, ERPC_DEFAULT_BUFFERS_COUNT >> 3);
+        (void)memset(m_freeBufferBitmap, 0xff, sizeof(m_freeBufferBitmap));
         (void)memset(m_buffers, 0, sizeof(m_buffers));
     }
 
@@ -112,8 +112,12 @@ public:
     }
 
 protected:
-    uint8_t m_freeBufferBitmap[(ERPC_DEFAULT_BUFFERS_COUNT >> 3U) + 1U];     /*!< Bitmat of used/not used buffers. */
-    uint64_t m_buffers[ERPC_DEFAULT_BUFFERS_COUNT][ERPC_BUFFER_SIZE_UINT64]; /*!< Static buffers. */
+    //! Bitmap representing which buffers are in use. A bit value of 1 means free and 0 means in
+    //! use.
+    uint8_t m_freeBufferBitmap[(ERPC_DEFAULT_BUFFERS_COUNT >> 3U) +
+                               (ERPC_DEFAULT_BUFFERS_COUNT % 8 ? 1U : 0U)];
+    //! Static buffers
+    uint64_t m_buffers[ERPC_DEFAULT_BUFFERS_COUNT][ERPC_BUFFER_SIZE_UINT64];
 #if !ERPC_THREADS_IS(NONE)
     Semaphore m_semaphore; /*!< Semaphore.*/
 #endif

--- a/erpc_c/setup/erpc_setup_mbf_static.cpp
+++ b/erpc_c/setup/erpc_setup_mbf_static.cpp
@@ -22,8 +22,8 @@
 
 using namespace erpc;
 
-#define ERPC_BUFFER_SIZE_UINT8 ((ERPC_DEFAULT_BUFFER_SIZE + sizeof(uint64_t) - 1))
-#define ERPC_BUFFER_SIZE_UINT64 (ERPC_BUFFER_SIZE_UINT8 / sizeof(uint64_t))
+#define ERPC_BUFFER_SIZE_UINT64 \
+    ((ERPC_DEFAULT_BUFFER_SIZE + sizeof(uint64_t) - 1) / sizeof(uint64_t))
 
 ////////////////////////////////////////////////////////////////////////////////
 // Classes
@@ -44,7 +44,7 @@ public:
 #endif
     {
         (void)memset(m_freeBufferBitmap, 0xff, ERPC_DEFAULT_BUFFERS_COUNT >> 3);
-        (void)memset(m_buffers, 0, ERPC_DEFAULT_BUFFERS_COUNT * ERPC_BUFFER_SIZE_UINT8);
+        (void)memset(m_buffers, 0, sizeof(m_buffers));
     }
 
     /*!


### PR DESCRIPTION
The memset of the m_buffers variable was not being done correctly.

For example, consider:
  ERPC_DEFAULT_BUFFERS_COUNT=3
  ERPC_DEFAULT_BUFFER_SIZE=24

ERPC_BUFFER_SIZE_UINT8 would be (24 + 8 - 1) = 31
ERPC_BUFFER_SIZE_UINT64 would be (31 / 8) = 3
The size of the memset would be (3 * 31) = 93
The size of the array would be (8 * 3 * 3) = 72

So in this example, the memset would go (93 - 72) = 21 bytes past the
end of the array.