### PR TITLE
Fix syntax errors in Python erpcgen ouput 

### DIFF
--- a/erpcgen/src/templates/py_common.template
+++ b/erpcgen/src/templates/py_common.template
@@ -57,7 +57,7 @@ class {$s.name}(object):
 {%   endfor -- union cases %}
 
 {% endfor -- members %}
-    def __init__(self{% for m in s.members if ((not m.lengthForMember) && m.type.type != 'union') %}, {$m.name}=None{% endfor %}):
+    def __init__(self{% for m in s.members if ((not m.lengthForMember) && (m.type.type != 'union' or m.type.isNonEncapsulatedUnion)) %}, {$m.name}=None{% endfor %}):
 {% for m in s.members if not m.lengthForMember %}
 {%     if (m.type.type == 'union' && m.type.isNonEncapsulatedUnion == false) %}
         self.{$m.name} = self.{$m.name}_union # {$prettyTypeName(m.name, m.type)}
@@ -83,7 +83,7 @@ class {$s.name}(object):
             {$self_m_name} = None
 {%   else -- isNullable %}
 {%    if (m.type.type == 'union' && m.type.isNonEncapsulatedUnion == true) %}
-        {$self_m_name}, self.{$m.discriminator} = common.{$m.type.name}()._read(codec)
+        {$self_m_name}, self.{$m.discriminator} = {$m.type.name}()._read(codec)
 {%    else -- isNonEncapsulatedUnion %}
         {$decodeValue(m.type, self_m_name, "", "codec", "        ", 0)}
 {%    endif -- isNonEncapsulatedUnion %}


### PR DESCRIPTION
Fixes two issues in generated Python code related to structures containing unencapsulated unions. To better illustrate: 

Given an IDL with this structure, union and discriminator:

```c
enum TypeExample {
  DESC_FLT,
  DESC_U32
}

union UnionExample {
  case DESC_FLT:
    float flt
  case DESC_U32:
    uint32 u32
}

struct StructExample {
  UnionExample value @discriminator(kind);
  TypeExample kind
}
```

erpcgen will produce this somewhat broken Python code in common.py:

```python
# Structures data types declarations
class StructExample(object):
    def __init__(self, kind=None):
        # syntax error! value not defined
        self.value = value # UnionExample
        self.kind = kind # TypeExample

    def _read(self, codec):
        # syntax error - common not defined (already in common module)
        self.value, self.kind = common.UnionExample()._read(codec) 
        return self
  # ...
```

Output after this PR:

```python
# Structures data types declarations
class StructExample(object):
    def __init__(self, value=None, kind=None):
        self.value = value # UnionExample
        self.kind = kind # TypeExample

    def _read(self, codec):
        self.value, self.kind = UnionExample()._read(codec)
        return self
  # ...
```