### PR TITLE
[38] Fixing error in erpc setup command: use_2to3 is invalid.

### DIFF
--- a/erpc_python/setup.py
+++ b/erpc_python/setup.py
@@ -43,6 +43,5 @@ setup(
         "Operating System :: POSIX :: Linux",
     ],
     keywords='rpc rpc-framework embedded multicore multiprocessor amp rpmsg_lite',
-    use_2to3=True,
     packages=['erpc'],
 )


### PR DESCRIPTION
This is fixing error in python3 installation. As python2 is very old and not maintained we may get rid of this parameter.

Additional to #38 

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>