### PR TITLE
Get rid for serial and enum34 dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ eRPC is available with an unrestrictive BSD 3-clause license. See the [LICENSE f
 [Example IDL](examples/README.md) is available in the `examples/` folder.
 
 Plenty of eRPC multicore and multiprocessor examples can be also found in NXP MCUXpressoSDK packages. Visit [https://mcuxpresso.nxp.com](https://mcuxpresso.nxp.com) to configure, build and download these packages.<br>
-To get the board list with multicore support (eRPC included) use filtering based on Middleware and search for 'multicore' string. Once the selected package with the multicore middleware is downloaded, see<br> 
+To get the board list with multicore support (eRPC included) use filtering based on Middleware and search for 'multicore' string. Once the selected package with the multicore middleware is downloaded, see<br>
 <MCUXpressoSDK_install_dir>/boards/<board_name>/multicore_examples for eRPC multicore examples (RPMsg_Lite or Messaging Unit transports used) or<br>
 <MCUXpressoSDK_install_dir>/boards/<board_name>/multiprocessor_examples for eRPC multiprocessor examples (UART or SPI transports used).<br>
-eRPC examples use the 'erpc_' name prefix. 
+eRPC examples use the 'erpc_' name prefix.
 
 Another way of getting NXP MCUXpressoSDK eRPC multicore and multiprocessor examples is using the [mcux-sdk](https://github.com/NXPmicro/mcux-sdk) Github repo. Follow the description how to use the West tool
 to clone and update the mcuxsdk repo in [readme Overview section](https://github.com/NXPmicro/mcux-sdk#overview). Once done the armgcc eRPC examples can be found in<br>
@@ -157,7 +157,7 @@ Install these packages:
 * flex: A fast lexical analyzer generator
 * libboost-dev, libboost-filesystem-dev, libboost-system-dev: Boost C++ libraries (Linux needs to use libboost version 1.65.0)
 * make: the GNU version of the 'make' utility
-* python: Python language interpreter (either 2.7 or 3.5+ work)
+* python: Python language interpreter 3.6+ work
 * gcc-7: GNU C compiler (recommended version)
 * g++-7: GNU C++ compiler (recommended version)
 

--- a/erpc_python/erpc/transport.py
+++ b/erpc_python/erpc/transport.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2015-2016 Freescale Semiconductor, Inc.
 # Copyright 2016-2021 NXP
+# Copyright 2022 ACRIOS Systems s.r.o.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/erpc_python/erpc/transport.py
+++ b/erpc_python/erpc/transport.py
@@ -7,11 +7,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import struct
-import serial
 import socket
 import threading
 from .crc16 import Crc16
 from .client import RequestError
+
+try:
+    import serial
+    SerialReady = True
+except ImportError:
+    SerialReady = False
+
 try:
     from rpmsg.sysfs import RpmsgEndpoint
     RpmsgEndpointReady = True
@@ -94,6 +100,8 @@ class FramedTransport(Transport):
 class SerialTransport(FramedTransport):
     def __init__(self, url, baudrate, **kwargs):
         super(SerialTransport, self).__init__()
+        if not SerialReady:
+            raise ImportError("Please, install pySerial module (sudo pip3 install pyserial).")
         self._url = url
         self._serial = serial.serial_for_url(url, baudrate=baudrate, **kwargs) # 8N1 by default
 
@@ -166,8 +174,7 @@ class TCPTransport(FramedTransport):
 class RpmsgTransport(Transport):
     def __init__(self, ept_addr_local = None, ept_addr_remote = None, channel_name = None):
         if not RpmsgEndpointReady:
-            print("Please, install RPMsg from: https://github.com/EmbeddedRPC/erpc-imx-demos/tree/master/middleware/rpmsg-python")
-            raise ImportError
+            raise ImportError("Please, install RPMsg from: https://github.com/EmbeddedRPC/erpc-imx-demos/tree/master/middleware/rpmsg-python")
 
         if ept_addr_local is None:
             ept_addr_local = RpmsgEndpoint.LOCAL_DEFAULT_ADDRESS
@@ -200,8 +207,7 @@ class LIBUSBSIOSPITransport(FramedTransport):
         super(LIBUSBSIOSPITransport, self).__init__()
 
         if not LIBUSBSIOReady:
-            print("Please, install LIBUSBSIO module")
-            raise ImportError
+            raise ImportError("Please, install LIBUSBSIO module")
 
         if baudrate is None:
             baudrate = 500000
@@ -253,10 +259,10 @@ class LIBUSBSIOSPITransport(FramedTransport):
         max_num_bytes = self.sio.GetMaxDataSize ()
         print('Max number of bytes supported for I2C/SPI transfers: %d \r\n' % max_num_bytes)
 
-        # Call SPI_Open and store the _hSPIPort handler 
+        # Call SPI_Open and store the _hSPIPort handler
         self._hSPIPort = self.sio.SPI_Open (int(self._baudrate), portNum=0, dataSize=8, preDelay=0)
 
-        # Configure GPIO pin for SPI master-slave signalling 
+        # Configure GPIO pin for SPI master-slave signalling
         res = self.sio.GPIO_ConfigIOPin (self._gpioport, self._gpiopin, self._gpiomode)
         print('GPIO_ConfigIOPin res: %d \r\n' % res)
         res = self.sio.GPIO_SetPortInDir (self._gpioport, self._gpiopin)
@@ -271,7 +277,7 @@ class LIBUSBSIOSPITransport(FramedTransport):
         self._hSIOPort = None
 
     def _base_send(self, message):
-        # Wait for SPI master-slave signalling GPIO pin to be in low state 
+        # Wait for SPI master-slave signalling GPIO pin to be in low state
         res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
         while (1 == res):
             res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
@@ -303,8 +309,7 @@ class LIBUSBSIOI2CTransport(FramedTransport):
         super(LIBUSBSIOI2CTransport, self).__init__()
 
         if not LIBUSBSIOReady:
-            print("Please, install LIBUSBSIO module")
-            raise ImportError
+            raise ImportError("Please, install LIBUSBSIO module")
 
         if baudrate is None:
             baudrate = 100000
@@ -354,10 +359,10 @@ class LIBUSBSIOI2CTransport(FramedTransport):
         max_num_bytes = self.sio.GetMaxDataSize ()
         print('Max number of bytes supported for SPI/I2C transfers: %d \r\n' % max_num_bytes)
 
-        # Call I2C_Open and store the _hI2CPort handler 
+        # Call I2C_Open and store the _hI2CPort handler
         self._hI2CPort = self.sio.I2C_Open (int(self._baudrate), 0, 0)
 
-        # Configure GPIO pin for I2C master-slave signalling 
+        # Configure GPIO pin for I2C master-slave signalling
         res = self.sio.GPIO_ConfigIOPin (self._gpioport, self._gpiopin, self._gpiomode)
         print('GPIO_ConfigIOPin res: %d \r\n' % res)
         res = self.sio.GPIO_SetPortInDir (self._gpioport, self._gpiopin)
@@ -372,7 +377,7 @@ class LIBUSBSIOI2CTransport(FramedTransport):
         self._hSIOPort = None
 
     def _base_send(self, message):
-        # Wait for I2C master-slave signalling GPIO pin to be in low state 
+        # Wait for I2C master-slave signalling GPIO pin to be in low state
         res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
         while (1 == res):
             res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
@@ -386,7 +391,7 @@ class LIBUSBSIOI2CTransport(FramedTransport):
             print('I2C transfer error: %d' % rxbytesnumber)
 
     def _base_receive(self, count):
-        # Wait for I2C master-slave signalling GPIO pin to be in low state 
+        # Wait for I2C master-slave signalling GPIO pin to be in low state
         res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
         while (1 == res):
             res = self.sio.GPIO_GetPin (self._gpioport, self._gpiopin)
@@ -399,4 +404,3 @@ class LIBUSBSIOI2CTransport(FramedTransport):
             #print('I2C transfer error: %d' % rxbytesnumber)
             res = self._hI2CPort.Reset ()
             return b"\00" * count
- 

--- a/erpc_python/setup.py
+++ b/erpc_python/setup.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2016 Freescale Semiconductor, Inc.
 # Copyright 2016-2019 NXP
+# Copyright 2022 ACRIOS Systems s.r.o.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/erpc_python/setup.py
+++ b/erpc_python/setup.py
@@ -33,7 +33,7 @@ setup(
     author="NXP",
     url='https://github.com/embeddedrpc/erpc',
     license="BSD 3-Clause",
-    install_requires=["enum34","pyserial"],
+    install_requires=[],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",

--- a/erpcgen/test/conftest.py
+++ b/erpcgen/test/conftest.py
@@ -51,49 +51,8 @@ erpc_dir = test_dir.dirpath().dirpath()
 # Add erpc python dir to search path.
 sys.path.append(str(erpc_dir.join("erpc_python")))
 
-# Provide symlink support under Windows for Python 2.7.
-if sys.version_info[:2] <= (2, 7) and os.name == "nt":
-    import ctypes
-
-    ## @brief Symlink function for python27 under windows.
-    #
-    # based on page: http://stackoverflow.com/questions/6260149/os-symlink-support-in-windows
-    def symlink_ms(source, link_name):
-        csl = ctypes.windll.kernel32.CreateSymbolicLinkW
-        csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
-        csl.restype = ctypes.c_ubyte
-        err = csl(link_name, source.replace('/', '\\'), 1)
-        if err == 0:
-           raise IOError(err, "failed to create symbolic link", link_name)
-
-    ## @brief islink function for python27 under windows.
-    #
-    # based on page: http://stackoverflow.com/questions/15258506/os-path-islink-on-windows-with-python
-    def islink_ms(link):
-        path = link.strpath
-        if os.path.exists(path):
-            if os.path.isdir(path):
-                FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
-                attributes = ctypes.windll.kernel32.GetFileAttributesW(unicode(path))
-                return (attributes & FILE_ATTRIBUTE_REPARSE_POINT) > 0
-            else:
-                command = ['dir', path]
-                try:
-                    with open(os.devnull, 'w') as NULL_FILE:
-                        o0 = subprocess.check_output(command, stderr=NULL_FILE, shell=True)
-                except subprocess.CalledProcessError as e:
-                    print(e.output)
-                    return False
-                o1 = [s.strip() for s in o0.split('\n')]
-                if len(o1) < 6:
-                    return False
-                else:
-                    return 'SYMLINK' in o1[5]
-        else:
-            return False
-
-    create_symlink = symlink_ms
-    islink = islink_ms
+if sys.version_info[:2] <= (3, 5):
+    raise Exception("Unsupported python version")
 else:
     create_symlink = os.symlink
     islink = lambda link: link.islink()

--- a/erpcgen/test/readme.md
+++ b/erpcgen/test/readme.md
@@ -12,7 +12,7 @@ boost test in boost folder.
 Setup
 -----
 
-Python 2.7.x is required. It will also work with Python 3.5+.
+Python 3.6+ is required.
 
 py.test(**Version 5.0.0-**) and pyYAML are required to run the tests. These can be installed via pip.
 
@@ -316,5 +316,3 @@ Todo
 - Compile tests working on Windows
 - Warn if test case names are not unique
 - Collect code coverage data for erpcgen
-
-

--- a/examples/matrix_multiply_tcp_python/readme.md
+++ b/examples/matrix_multiply_tcp_python/readme.md
@@ -8,7 +8,7 @@ eRPC is open-source project stored on github: https://github.com/EmbeddedRPC/erp
 eRPC documentation can be also found in: https://github.com/EmbeddedRPC/erpc/wiki
 
 # Prerequisites
-- Python 2.7 or 3.x
+- Python 3.6+
 
 # eRPC installation\
 1. run `python setup.py install` in folder `erpc/erpc_python/`
@@ -20,11 +20,11 @@ eRPC documentation can be also found in: https://github.com/EmbeddedRPC/erpc/wik
 - `service/erpc_matrix_multiply/`: eRPC output shim code generated from IDL file
 
 # Running the example
-- Run `matrix_multiply.py` with `-s` (or `--server`) parameter to run server 
+- Run `matrix_multiply.py` with `-s` (or `--server`) parameter to run server
 - Run `matrix_multiply.py` with `-c` (or `--client`) parameter to run client
 - Both server and client has to have specified host and port with `-t` (`--host`) and `-p` (`--port`) parameters. By default is host set as localhost and port as 40.
 
-## Example: 
+## Example:
 ```
   python matrix_multiply.py --server --host 192.168.1.10 --port 40
   python matrix_multiply.py --client --host 192.168.1.10 --port 40


### PR DESCRIPTION
enum34 is in python3 since 3.4 (from 2014)
why to install serial module when i want to use other transport

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>