### PR TITLE
fix compile error:UniqueIdChecker.cpp:156:104:'sort' was not declared…

### DIFF
--- a/erpcgen/src/UniqueIdChecker.cpp
+++ b/erpcgen/src/UniqueIdChecker.cpp
@@ -15,6 +15,7 @@
 #include "Symbol.h"
 #include "annotations.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <sstream>
 


### PR DESCRIPTION
fix compile error:UniqueIdChecker.cpp:156:104:'sort' was not declared in this scope, 
environment: OS Ubuntu 16.04,Compiler gcc 5.4.0
use 'sort' function defined in <algorithm>,but not include the header.

