### PR TITLE
Don't check for null pointer before free, it should be handled in the free function

### DIFF
--- a/erpc_c/port/erpc_port.h
+++ b/erpc_c/port/erpc_port.h
@@ -40,7 +40,7 @@ void *erpc_malloc(size_t size);
 /*!
  * @brief This function free given memory block.
  *
- * @param[in] ptr Pointer to memory which should be freed.
+ * @param[in] ptr Pointer to memory which should be freed, or NULL.
  */
 void erpc_free(void *ptr);
 

--- a/erpcgen/src/templates/c_common_functions.template
+++ b/erpcgen/src/templates/c_common_functions.template
@@ -377,10 +377,7 @@ else
 
 {# ---------------- freeData ---------------- #}
 {% def freeData(info) %}
-if ({$info.freeName})
-{
-    erpc_free({$info.freeName});
-}
+erpc_free({$info.freeName});
 {% enddef ------------------------------- freeData %}
 
 {# ---------------- freeStruct ---------------- #}
@@ -400,10 +397,7 @@ if ({$info.name})
 {% if info.needFreeingCall == true %}
 {$freeArray(info)}
 {% endif %}
-if ({$info.name})
-{
-    erpc_free({$info.name});
-}
+erpc_free({$info.name});
 {% enddef ------------------------------- freeList %}
 
 {# ---------------- freeArray ---------------- #}


### PR DESCRIPTION
# Pull request

**Choose Correct**

- [ X] bug
- [ ] feature

**Describe the pull request**
<!--
Stop checking if pointer is NULL before sending it to the erpc_free function. The erpc_free should handle NULL pointer properly (like c standard free)
-->

**To Reproduce**
<!--
Generate code that allocating space on the heap.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->: Windows
- eRPC Version<!--[e.g. v1.9.0]-->: 1.8.1

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [ ] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
