### PR TITLE
Add defines for changing transport to endianness agnostic

### DIFF
--- a/erpc_c/config/erpc_config.h
+++ b/erpc_c/config/erpc_config.h
@@ -183,96 +183,110 @@
 
 //! @name Assert function definition
 //@{
-//! User custom asser defition. Include header file if needed before bellow line. If assert is not enabled, default will be used.
+//! User custom asser defition. Include header file if needed before bellow line. If assert is not enabled, default will
+//! be used.
 // #define erpc_assert(condition)
 //@}
-
 
 //! @def ERPC_WRITE_AGNOSTIC_16(value)
 //!
 //! Write int16_t and uint16_t in decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_WRITE_AGNOSTIC_16(value)
 
 //! @def ERPC_WRITE_AGNOSTIC_32(value)
 //!
 //! Write int32_t and uint32_t in decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_WRITE_AGNOSTIC_32(value)
 
 //! @def ERPC_WRITE_AGNOSTIC_64(value)
 //!
 //! Write int64_t and uint64_t in decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_WRITE_AGNOSTIC_64(value)
 
 //! @def ERPC_WRITE_AGNOSTIC_FLOAT(value)
 //!
-//! Write float in decided transport layer format and byte order, needed when processors uses different endianness/format for floats.
+//! Write float in decided transport layer format and byte order, needed when processors uses different
+//! endianness/format for floats.
 //!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
+//! layer byte order/format.
 //#define ERPC_WRITE_AGNOSTIC_FLOAT(value)
 
 //! @def ERPC_WRITE_AGNOSTIC_DOUBLE(value)
 //!
-//! Write double in decided transport layer format and byte order, needed when processors uses different endianness/format for doubles.
+//! Write double in decided transport layer format and byte order, needed when processors uses different
+//! endianness/format for doubles.
 //!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
+//! layer byte order/format.
 //#define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
 
 //! @def ERPC_WRITE_AGNOSTIC_PTR(value)
 //!
 //! Write pointer in decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current
+//! order is not transport layer byte order.
 //#define ERPC_WRITE_AGNOSTIC_PTR(value)
 
 //! @def ERPC_READ_AGNOSTIC_16(value)
 //!
 //! Read int16_t and uint16_t from decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_READ_AGNOSTIC_16(value)
 
 //! @def ERPC_READ_AGNOSTIC_32(value)
 //!
 //! Read int32_t and uint32_t from decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_READ_AGNOSTIC_32(value)
 
 //! @def ERPC_READ_AGNOSTIC_64(value)
 //!
 //! Read int64_t and uint64_t from decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport
+//! layer byte order.
 //#define ERPC_READ_AGNOSTIC_64(value)
 
 //! @def ERPC_READ_AGNOSTIC_FLOAT(value)
 //!
-//! Read float from decided transport layer format and byte order, needed when processors uses different endianness/format for floats.
+//! Read float from decided transport layer format and byte order, needed when processors uses different
+//! endianness/format for floats.
 //!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
+//! layer byte order/format.
 //#define ERPC_READ_AGNOSTIC_FLOAT(value)
 
 //! @def ERPC_READ_AGNOSTIC_DOUBLE(value)
 //!
-//! Read double from decided transport layer format and byte order, needed when processors uses different endianness/format for doubles.
+//! Read double from decided transport layer format and byte order, needed when processors uses different
+//! endianness/format for doubles.
 //!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
+//! layer byte order/format.
 //#define ERPC_READ_AGNOSTIC_DOUBLE(value)
 
 //! @def ERPC_READ_AGNOSTIC_PTR(value)
 //!
 //! Read pointer from decided transport layer byte order, needed when processors uses different endianness.
 //!
-//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current order is not transport layer byte order.
+//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current
+//! order is not transport layer byte order.
 //#define ERPC_READ_AGNOSTIC_PTR(value)
-
-
 
 /*! @} */
 #endif // _ERPC_CONFIG_H_

--- a/erpc_c/config/erpc_config.h
+++ b/erpc_c/config/erpc_config.h
@@ -188,105 +188,21 @@
 // #define erpc_assert(condition)
 //@}
 
-//! @def ERPC_WRITE_AGNOSTIC_16(value)
+//! @def ENDIANES_HEADER
 //!
-//! Write int16_t and uint16_t in decided transport layer byte order, needed when processors uses different endianness.
+//! Include header file that controls the communication endianness
 //!
-//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_WRITE_AGNOSTIC_16(value)
-
-//! @def ERPC_WRITE_AGNOSTIC_32(value)
-//!
-//! Write int32_t and uint32_t in decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_WRITE_AGNOSTIC_32(value)
-
-//! @def ERPC_WRITE_AGNOSTIC_64(value)
-//!
-//! Write int64_t and uint64_t in decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_WRITE_AGNOSTIC_64(value)
-
-//! @def ERPC_WRITE_AGNOSTIC_FLOAT(value)
-//!
-//! Write float in decided transport layer format and byte order, needed when processors uses different
-//! endianness/format for floats.
-//!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
-//! layer byte order/format.
-//#define ERPC_WRITE_AGNOSTIC_FLOAT(value)
-
-//! @def ERPC_WRITE_AGNOSTIC_DOUBLE(value)
-//!
-//! Write double in decided transport layer format and byte order, needed when processors uses different
-//! endianness/format for doubles.
-//!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
-//! layer byte order/format.
-//#define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
-
-//! @def ERPC_WRITE_AGNOSTIC_PTR(value)
-//!
-//! Write pointer in decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current
-//! order is not transport layer byte order.
-//#define ERPC_WRITE_AGNOSTIC_PTR(value)
-
-//! @def ERPC_READ_AGNOSTIC_16(value)
-//!
-//! Read int16_t and uint16_t from decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_READ_AGNOSTIC_16(value)
-
-//! @def ERPC_READ_AGNOSTIC_32(value)
-//!
-//! Read int32_t and uint32_t from decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_READ_AGNOSTIC_32(value)
-
-//! @def ERPC_READ_AGNOSTIC_64(value)
-//!
-//! Read int64_t and uint64_t from decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport
-//! layer byte order.
-//#define ERPC_READ_AGNOSTIC_64(value)
-
-//! @def ERPC_READ_AGNOSTIC_FLOAT(value)
-//!
-//! Read float from decided transport layer format and byte order, needed when processors uses different
-//! endianness/format for floats.
-//!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
-//! layer byte order/format.
-//#define ERPC_READ_AGNOSTIC_FLOAT(value)
-
-//! @def ERPC_READ_AGNOSTIC_DOUBLE(value)
-//!
-//! Read double from decided transport layer format and byte order, needed when processors uses different
-//! endianness/format for doubles.
-//!
-//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport
-//! layer byte order/format.
-//#define ERPC_READ_AGNOSTIC_DOUBLE(value)
-
-//! @def ERPC_READ_AGNOSTIC_PTR(value)
-//!
-//! Read pointer from decided transport layer byte order, needed when processors uses different endianness.
-//!
-//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current
-//! order is not transport layer byte order.
-//#define ERPC_READ_AGNOSTIC_PTR(value)
+//! Uncomment for example behaviour for endianness agnostic with:
+//!  1. communication in little endian.
+//!  2. current processor is big endian.
+//!  3. pointer size is 32 bit.
+//!  4. float+double scheme not defined, so throws assert if passes.
+//! #define ERPC_PROCESSOR_ENDIANNESS_LITTLE 0
+//! #define ERPC_COMMUNICATION_LITTLE        1
+//! #define ERPC_POINTER_SIZE_16             0
+//! #define ERPC_POINTER_SIZE_32             1
+//! #define ERPC_POINTER_SIZE_64             0
+//! #define ENDIANES_HEADER "erpc_endianness_agnostic_example.h"
 
 /*! @} */
 #endif // _ERPC_CONFIG_H_

--- a/erpc_c/config/erpc_config.h
+++ b/erpc_c/config/erpc_config.h
@@ -188,6 +188,92 @@
 //@}
 
 
+//! @def ERPC_WRITE_AGNOSTIC_16(value)
+//!
+//! Write int16_t and uint16_t in decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport layer byte order.
+//#define ERPC_WRITE_AGNOSTIC_16(value)
+
+//! @def ERPC_WRITE_AGNOSTIC_32(value)
+//!
+//! Write int32_t and uint32_t in decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport layer byte order.
+//#define ERPC_WRITE_AGNOSTIC_32(value)
+
+//! @def ERPC_WRITE_AGNOSTIC_64(value)
+//!
+//! Write int64_t and uint64_t in decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport layer byte order.
+//#define ERPC_WRITE_AGNOSTIC_64(value)
+
+//! @def ERPC_WRITE_AGNOSTIC_FLOAT(value)
+//!
+//! Write float in decided transport layer format and byte order, needed when processors uses different endianness/format for floats.
+//!
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//#define ERPC_WRITE_AGNOSTIC_FLOAT(value)
+
+//! @def ERPC_WRITE_AGNOSTIC_DOUBLE(value)
+//!
+//! Write double in decided transport layer format and byte order, needed when processors uses different endianness/format for doubles.
+//!
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//#define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
+
+//! @def ERPC_WRITE_AGNOSTIC_PTR(value)
+//!
+//! Write pointer in decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current order is not transport layer byte order.
+//#define ERPC_WRITE_AGNOSTIC_PTR(value)
+
+//! @def ERPC_READ_AGNOSTIC_16(value)
+//!
+//! Read int16_t and uint16_t from decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_16(value)] if current order is not transport layer byte order.
+//#define ERPC_READ_AGNOSTIC_16(value)
+
+//! @def ERPC_READ_AGNOSTIC_32(value)
+//!
+//! Read int32_t and uint32_t from decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_32(value)] if current order is not transport layer byte order.
+//#define ERPC_READ_AGNOSTIC_32(value)
+
+//! @def ERPC_READ_AGNOSTIC_64(value)
+//!
+//! Read int64_t and uint64_t from decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [for example, (value) = __bswap_64(value)] if current order is not transport layer byte order.
+//#define ERPC_READ_AGNOSTIC_64(value)
+
+//! @def ERPC_READ_AGNOSTIC_FLOAT(value)
+//!
+//! Read float from decided transport layer format and byte order, needed when processors uses different endianness/format for floats.
+//!
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//#define ERPC_READ_AGNOSTIC_FLOAT(value)
+
+//! @def ERPC_READ_AGNOSTIC_DOUBLE(value)
+//!
+//! Read double from decided transport layer format and byte order, needed when processors uses different endianness/format for doubles.
+//!
+//! Uncomment and add your implementation [Dependant on your architecture] if current order/format is not transport layer byte order/format.
+//#define ERPC_READ_AGNOSTIC_DOUBLE(value)
+
+//! @def ERPC_READ_AGNOSTIC_PTR(value)
+//!
+//! Read pointer from decided transport layer byte order, needed when processors uses different endianness.
+//!
+//! Uncomment and add your implementation [probably using one of the above defines with correct num of bits] if current order is not transport layer byte order.
+//#define ERPC_READ_AGNOSTIC_PTR(value)
+
+
+
 /*! @} */
 #endif // _ERPC_CONFIG_H_
 ////////////////////////////////////////////////////////////////////////////////

--- a/erpc_c/config/erpc_config.h
+++ b/erpc_c/config/erpc_config.h
@@ -202,7 +202,7 @@
 //! #define ERPC_POINTER_SIZE_16             0
 //! #define ERPC_POINTER_SIZE_32             1
 //! #define ERPC_POINTER_SIZE_64             0
-//! #define ENDIANES_HEADER "erpc_endianness_agnostic_example.h"
+//! #define ENDIANNESS_HEADER "erpc_endianness_agnostic_example.h"
 
 /*! @} */
 #endif // _ERPC_CONFIG_H_

--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -8,8 +8,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "erpc_config_internal.h"
 #include "erpc_basic_codec.h"
+
+#include "erpc_config_internal.h"
 #include "erpc_manually_constructed.h"
 
 #if ERPC_ALLOCATION_POLICY == ERPC_ALLOCATION_POLICY_DYNAMIC
@@ -27,7 +28,8 @@ const uint32_t BasicCodec::kBasicCodecVersion = 1UL;
 
 void BasicCodec::startWriteMessage(message_type_t type, uint32_t service, uint32_t request, uint32_t sequence)
 {
-    uint32_t header = (kBasicCodecVersion << 24u) | ((service & 0xffu) << 16u) | ((request & 0xffu) << 8u) | ((uint32_t)type & 0xffu);
+    uint32_t header =
+        (kBasicCodecVersion << 24u) | ((service & 0xffu) << 16u) | ((request & 0xffu) << 8u) | ((uint32_t)type & 0xffu);
 
     write(header);
 

--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -11,6 +11,8 @@
 #include "erpc_basic_codec.h"
 
 #include "erpc_config_internal.h"
+#include ENDIANES_HEADER
+
 #include "erpc_manually_constructed.h"
 
 #if ERPC_ALLOCATION_POLICY == ERPC_ALLOCATION_POLICY_DYNAMIC

--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -9,10 +9,8 @@
  */
 
 #include "erpc_basic_codec.h"
-
 #include "erpc_config_internal.h"
-#include ENDIANES_HEADER
-
+#include ENDIANNESS_HEADER
 #include "erpc_manually_constructed.h"
 
 #if ERPC_ALLOCATION_POLICY == ERPC_ALLOCATION_POLICY_DYNAMIC

--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "erpc_config_internal.h"
 #include "erpc_basic_codec.h"
 #include "erpc_manually_constructed.h"
 
@@ -56,16 +57,22 @@ void BasicCodec::write(int8_t value)
 
 void BasicCodec::write(int16_t value)
 {
+    ERPC_WRITE_AGNOSTIC_16(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(int32_t value)
 {
+    ERPC_WRITE_AGNOSTIC_32(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(int64_t value)
 {
+    ERPC_WRITE_AGNOSTIC_64(value);
+
     writeData(&value, sizeof(value));
 }
 
@@ -76,26 +83,36 @@ void BasicCodec::write(uint8_t value)
 
 void BasicCodec::write(uint16_t value)
 {
+    ERPC_WRITE_AGNOSTIC_16(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(uint32_t value)
 {
+    ERPC_WRITE_AGNOSTIC_32(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(uint64_t value)
 {
+    ERPC_WRITE_AGNOSTIC_64(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(float value)
 {
+    ERPC_WRITE_AGNOSTIC_FLOAT(value);
+
     writeData(&value, sizeof(value));
 }
 
 void BasicCodec::write(double value)
 {
+    ERPC_WRITE_AGNOSTIC_DOUBLE(value);
+
     writeData(&value, sizeof(value));
 }
 
@@ -104,6 +121,8 @@ void BasicCodec::writePtr(uintptr_t value)
     uint8_t ptrSize = (uint8_t)sizeof(value);
 
     write(ptrSize);
+
+    ERPC_WRITE_AGNOSTIC_PTR(value);
 
     writeData(&value, ptrSize);
 }
@@ -218,16 +237,28 @@ void BasicCodec::read(int8_t *value)
 void BasicCodec::read(int16_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_16(*value);
+    }
 }
 
 void BasicCodec::read(int32_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_32(*value);
+    }
 }
 
 void BasicCodec::read(int64_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_64(*value);
+    }
 }
 
 void BasicCodec::read(uint8_t *value)
@@ -238,26 +269,46 @@ void BasicCodec::read(uint8_t *value)
 void BasicCodec::read(uint16_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_16(*value);
+    }
 }
 
 void BasicCodec::read(uint32_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_32(*value);
+    }
 }
 
 void BasicCodec::read(uint64_t *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_64(*value);
+    }
 }
 
 void BasicCodec::read(float *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_FLOAT(*value);
+    }
 }
 
 void BasicCodec::read(double *value)
 {
     readData(value, sizeof(*value));
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_DOUBLE(*value);
+    }
 }
 
 void BasicCodec::readPtr(uintptr_t *value)
@@ -272,6 +323,10 @@ void BasicCodec::readPtr(uintptr_t *value)
     }
 
     readData(value, ptrSize);
+    if (isStatusOk())
+    {
+        ERPC_READ_AGNOSTIC_PTR(*value);
+    }
 }
 
 void BasicCodec::readString(uint32_t *length, char **value)

--- a/erpc_c/infra/erpc_framed_transport.cpp
+++ b/erpc_c/infra/erpc_framed_transport.cpp
@@ -11,6 +11,7 @@
 #include "erpc_framed_transport.h"
 
 #include "erpc_config_internal.h"
+#include ENDIANNESS_HEADER
 #include "erpc_message_buffer.h"
 
 #include <cstdio>

--- a/erpc_c/infra/erpc_framed_transport.cpp
+++ b/erpc_c/infra/erpc_framed_transport.cpp
@@ -8,8 +8,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "erpc_config_internal.h"
 #include "erpc_framed_transport.h"
+
+#include "erpc_config_internal.h"
 #include "erpc_message_buffer.h"
 
 #include <cstdio>

--- a/erpc_c/infra/erpc_framed_transport.cpp
+++ b/erpc_c/infra/erpc_framed_transport.cpp
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "erpc_config_internal.h"
 #include "erpc_framed_transport.h"
 #include "erpc_message_buffer.h"
 
@@ -55,6 +56,9 @@ erpc_status_t FramedTransport::receive(MessageBuffer *message)
 
         if (retVal == kErpcStatus_Success)
         {
+            ERPC_READ_AGNOSTIC_16(h.m_messageSize);
+            ERPC_READ_AGNOSTIC_16(h.m_crc);
+
             // received size can't be zero.
             if (h.m_messageSize == 0U)
             {
@@ -112,6 +116,10 @@ erpc_status_t FramedTransport::send(MessageBuffer *message)
     // Send header first.
     h.m_messageSize = messageLength;
     h.m_crc = m_crcImpl->computeCRC16(message->get(), messageLength);
+
+    ERPC_WRITE_AGNOSTIC_16(h.m_messageSize);
+    ERPC_WRITE_AGNOSTIC_16(h.m_crc);
+
     ret = underlyingSend((uint8_t *)&h, sizeof(h));
     if (ret == kErpcStatus_Success)
     {

--- a/erpc_c/port/erpc_config_internal.h
+++ b/erpc_c/port/erpc_config_internal.h
@@ -219,43 +219,9 @@
     #endif
 #endif
 
-// Disabling endianness agnostic feature
-#if !defined(ERPC_WRITE_AGNOSTIC_16)
-    #define ERPC_WRITE_AGNOSTIC_16(value)
-#endif
-#if !defined(ERPC_WRITE_AGNOSTIC_32)
-    #define ERPC_WRITE_AGNOSTIC_32(value)
-#endif
-#if !defined(ERPC_WRITE_AGNOSTIC_64)
-    #define ERPC_WRITE_AGNOSTIC_64(value)
-#endif
-#if !defined(ERPC_WRITE_AGNOSTIC_FLOAT)
-    #define ERPC_WRITE_AGNOSTIC_FLOAT(value)
-#endif
-#if !defined(ERPC_WRITE_AGNOSTIC_DOUBLE)
-    #define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
-#endif
-#if !defined(ERPC_WRITE_AGNOSTIC_PTR)
-    #define ERPC_WRITE_AGNOSTIC_PTR(value)
-#endif
-
-#if !defined(ERPC_READ_AGNOSTIC_16)
-    #define ERPC_READ_AGNOSTIC_16(value)
-#endif
-#if !defined(ERPC_READ_AGNOSTIC_32)
-    #define ERPC_READ_AGNOSTIC_32(value)
-#endif
-#if !defined(ERPC_READ_AGNOSTIC_64)
-    #define ERPC_READ_AGNOSTIC_64(value)
-#endif
-#if !defined(ERPC_READ_AGNOSTIC_FLOAT)
-    #define ERPC_READ_AGNOSTIC_FLOAT(value)
-#endif
-#if !defined(ERPC_READ_AGNOSTIC_DOUBLE)
-    #define ERPC_READ_AGNOSTIC_DOUBLE(value)
-#endif
-#if !defined(ERPC_READ_AGNOSTIC_PTR)
-    #define ERPC_READ_AGNOSTIC_PTR(value)
+// Disabling endianness agnostic feature.
+#ifndef ENDIANES_HEADER
+    #define ENDIANES_HEADER "erpc_endianness_undefined.h"
 #endif
 
 /* clang-format on */

--- a/erpc_c/port/erpc_config_internal.h
+++ b/erpc_c/port/erpc_config_internal.h
@@ -219,6 +219,45 @@
     #endif
 #endif
 
+// Disabling endianness agnostic feature
+#if !defined(ERPC_WRITE_AGNOSTIC_16)
+    #define ERPC_WRITE_AGNOSTIC_16(value)
+#endif
+#if !defined(ERPC_WRITE_AGNOSTIC_32)
+    #define ERPC_WRITE_AGNOSTIC_32(value)
+#endif
+#if !defined(ERPC_WRITE_AGNOSTIC_64)
+    #define ERPC_WRITE_AGNOSTIC_64(value)
+#endif
+#if !defined(ERPC_WRITE_AGNOSTIC_FLOAT)
+    #define ERPC_WRITE_AGNOSTIC_FLOAT(value)
+#endif
+#if !defined(ERPC_WRITE_AGNOSTIC_DOUBLE)
+    #define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
+#endif
+#if !defined(ERPC_WRITE_AGNOSTIC_PTR)
+    #define ERPC_WRITE_AGNOSTIC_PTR(value)
+#endif
+
+#if !defined(ERPC_READ_AGNOSTIC_16)
+    #define ERPC_READ_AGNOSTIC_16(value)
+#endif
+#if !defined(ERPC_READ_AGNOSTIC_32)
+    #define ERPC_READ_AGNOSTIC_32(value)
+#endif
+#if !defined(ERPC_READ_AGNOSTIC_64)
+    #define ERPC_READ_AGNOSTIC_64(value)
+#endif
+#if !defined(ERPC_READ_AGNOSTIC_FLOAT)
+    #define ERPC_READ_AGNOSTIC_FLOAT(value)
+#endif
+#if !defined(ERPC_READ_AGNOSTIC_DOUBLE)
+    #define ERPC_READ_AGNOSTIC_DOUBLE(value)
+#endif
+#if !defined(ERPC_READ_AGNOSTIC_PTR)
+    #define ERPC_READ_AGNOSTIC_PTR(value)
+#endif
+
 /* clang-format on */
 #endif // _ERPC_DETECT_H_
 ////////////////////////////////////////////////////////////////////////////////

--- a/erpc_c/port/erpc_config_internal.h
+++ b/erpc_c/port/erpc_config_internal.h
@@ -220,8 +220,8 @@
 #endif
 
 // Disabling endianness agnostic feature.
-#ifndef ENDIANES_HEADER
-    #define ENDIANES_HEADER "erpc_endianness_undefined.h"
+#ifndef ENDIANNESS_HEADER
+    #define ENDIANNESS_HEADER "erpc_endianness_undefined.h"
 #endif
 
 /* clang-format on */

--- a/erpc_c/port/erpc_endianness_agnostic_example.h
+++ b/erpc_c/port/erpc_endianness_agnostic_example.h
@@ -1,0 +1,51 @@
+/*
+ * This is example file for endianness agnostic communication based on byteswap.h.
+ * Other approach can be done with htons(), htonl(), ntohs(), ntohl() and such.
+ */
+
+#ifndef _ERPC_ENDIANNESS_AGNOSTIC_EXAMPLE_H_
+#define _ERPC_ENDIANNESS_AGNOSTIC_EXAMPLE_H_
+
+#if ERPC_PROCESSOR_ENDIANNESS_LITTLE != ERPC_COMMUNICATION_LITTLE
+#include <byteswap.h>
+
+#define ERPC_WRITE_AGNOSTIC_16(value) (value) = __bswap_16(value);
+#define ERPC_WRITE_AGNOSTIC_32(value) (value) = __bswap_32(value);
+#define ERPC_WRITE_AGNOSTIC_64(value) (value) = __bswap_64(value);
+
+#define ERPC_READ_AGNOSTIC_16(value) (value) = __bswap_16(value);
+#define ERPC_READ_AGNOSTIC_32(value) (value) = __bswap_32(value);
+#define ERPC_READ_AGNOSTIC_64(value) (value) = __bswap_64(value);
+
+#if ERPC_POINTER_SIZE_16
+#define ERPC_WRITE_AGNOSTIC_PTR(value) ERPC_WRITE_AGNOSTIC_16(value)
+#define ERPC_READ_AGNOSTIC_PTR(value) ERPC_READ_AGNOSTIC_16(value)
+#elif ERPC_POINTER_SIZE_32
+#define ERPC_WRITE_AGNOSTIC_PTR(value) ERPC_WRITE_AGNOSTIC_32(value)
+#define ERPC_READ_AGNOSTIC_PTR(value) ERPC_READ_AGNOSTIC_32(value)
+#elif ERPC_POINTER_SIZE_64
+#define ERPC_WRITE_AGNOSTIC_PTR(value) ERPC_WRITE_AGNOSTIC_64(value)
+#define ERPC_READ_AGNOSTIC_PTR(value) ERPC_READ_AGNOSTIC_64(value)
+#else
+#error unknown pointer size
+#endif
+
+#else
+
+#define ERPC_WRITE_AGNOSTIC_16(value)
+#define ERPC_WRITE_AGNOSTIC_32(value)
+#define ERPC_WRITE_AGNOSTIC_64(value)
+#define ERPC_WRITE_AGNOSTIC_PTR(value)
+
+#define ERPC_READ_AGNOSTIC_16(value)
+#define ERPC_READ_AGNOSTIC_32(value)
+#define ERPC_READ_AGNOSTIC_64(value)
+#define ERPC_READ_AGNOSTIC_PTR(value)
+#endif
+
+#define ERPC_WRITE_AGNOSTIC_FLOAT(value) erpc_assert(0);
+#define ERPC_WRITE_AGNOSTIC_DOUBLE(value) erpc_assert(0);
+#define ERPC_READ_AGNOSTIC_FLOAT(value) erpc_assert(0);
+#define ERPC_READ_AGNOSTIC_DOUBLE(value) erpc_assert(0);
+
+#endif

--- a/erpc_c/port/erpc_endianness_undefined.h
+++ b/erpc_c/port/erpc_endianness_undefined.h
@@ -1,0 +1,20 @@
+
+#ifndef _ERPC_ENDIANNESS_UNDEFINED_H_
+#define _ERPC_ENDIANNESS_UNDEFINED_H_
+
+// Disabling endianness agnostic feature.
+#define ERPC_WRITE_AGNOSTIC_16(value)
+#define ERPC_WRITE_AGNOSTIC_32(value)
+#define ERPC_WRITE_AGNOSTIC_64(value)
+#define ERPC_WRITE_AGNOSTIC_FLOAT(value)
+#define ERPC_WRITE_AGNOSTIC_DOUBLE(value)
+#define ERPC_WRITE_AGNOSTIC_PTR(value)
+
+#define ERPC_READ_AGNOSTIC_16(value)
+#define ERPC_READ_AGNOSTIC_32(value)
+#define ERPC_READ_AGNOSTIC_64(value)
+#define ERPC_READ_AGNOSTIC_FLOAT(value)
+#define ERPC_READ_AGNOSTIC_DOUBLE(value)
+#define ERPC_READ_AGNOSTIC_PTR(value)
+
+#endif


### PR DESCRIPTION
# Pull request

**Choose Correct**

- [ ] bug
- [X] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Added defines for user for changing the bytes that transport to some endianness agnostic way he decide on.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->


**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:Windows
- eRPC Version<!--[e.g. v1.9.0]-->:1.9.0

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
Tested with two cores with different endianness, the core with little endian changed its endianness while read+write and the other didn't changed anything. 64 bit types and pointer types wasn't tested.
Fixes #106  