### PR TITLE
Fixed memmanager and add assertion

### DIFF
--- a/erpc_c/port/erpc_config_internal.h
+++ b/erpc_c/port/erpc_config_internal.h
@@ -196,7 +196,7 @@
 #endif
 
 #if !defined(erpc_assert)
-    #if ERPC_HAS_FREERTOSCONFIG_H 
+    #if ERPC_HAS_FREERTOSCONFIG_H
         #ifdef __cplusplus
             extern "C" {
         #endif

--- a/erpc_c/port/erpc_port_memmanager.cpp
+++ b/erpc_c/port/erpc_port_memmanager.cpp
@@ -13,17 +13,11 @@
 
 extern "C" {
 #include "FreeRTOS.h"
-#include "MemManager.h"
+#include "fsl_component_mem_manager.h"
 }
 
 #if !(__embedded_cplusplus)
 using namespace std;
-#endif
-
-/* Backward compatibility for older version of driver. */
-#if !defined(MEM_BufferAllocForever)
-    #define MEM_BufferAllocForever MEM_BufferAllocWithId
-    #define MEM_SUCCESS_c kStatus_MemSuccess
 #endif
 
 void *operator new(std::size_t count) THROW_BADALLOC
@@ -64,7 +58,7 @@ void operator delete[](void *ptr) THROW
 
 void *erpc_malloc(size_t size)
 {
-    void *p = MEM_BufferAllocForever(size, 0);
+    void *p = MEM_BufferAlloc(size);
     return p;
 }
 
@@ -72,7 +66,7 @@ void erpc_free(void *ptr)
 {
     if (ptr != NULL)
     {
-        erpc_assert(MEM_BufferFree(ptr) == MEM_SUCCESS_c);
+        erpc_assert(MEM_BufferFree(ptr) == kStatus_MemSuccess);
     }
 }
 

--- a/erpc_c/port/erpc_port_memmanager.cpp
+++ b/erpc_c/port/erpc_port_memmanager.cpp
@@ -64,7 +64,10 @@ void *erpc_malloc(size_t size)
 
 void erpc_free(void *ptr)
 {
-    erpc_assert(MEM_BufferFree(ptr) == kStatus_MemSuccess);
+    if (ptr != NULL)
+    {
+        erpc_assert(MEM_BufferFree(ptr) == kStatus_MemSuccess);
+    }
 }
 
 /* Provide function for pure virtual call to avoid huge demangling code being linked in ARM GCC */

--- a/erpc_c/port/erpc_port_memmanager.cpp
+++ b/erpc_c/port/erpc_port_memmanager.cpp
@@ -20,6 +20,12 @@ extern "C" {
 using namespace std;
 #endif
 
+/* Backward compatibility for older version of driver. */
+#if !defined(MEM_BufferAllocForever)
+    #define MEM_BufferAllocForever MEM_BufferAllocWithId
+    #define MEM_SUCCESS_c kStatus_MemSuccess
+#endif
+
 void *operator new(std::size_t count) THROW_BADALLOC
 {
     void *p = erpc_malloc(count);
@@ -58,7 +64,7 @@ void operator delete[](void *ptr) THROW
 
 void *erpc_malloc(size_t size)
 {
-    void *p = MEM_BufferAllocWithId(size, 0);
+    void *p = MEM_BufferAllocForever(size, 0);
     return p;
 }
 
@@ -66,7 +72,7 @@ void erpc_free(void *ptr)
 {
     if (ptr != NULL)
     {
-        erpc_assert(MEM_BufferFree(ptr) == kStatus_MemSuccess);
+        erpc_assert(MEM_BufferFree(ptr) == MEM_SUCCESS_c);
     }
 }
 

--- a/erpc_c/port/erpc_port_memmanager.cpp
+++ b/erpc_c/port/erpc_port_memmanager.cpp
@@ -58,13 +58,13 @@ void operator delete[](void *ptr) THROW
 
 void *erpc_malloc(size_t size)
 {
-    void *p = MEM_BufferAllocForever(size, 0);
+    void *p = MEM_BufferAllocWithId(size, 0);
     return p;
 }
 
 void erpc_free(void *ptr)
 {
-    MEM_BufferFree(ptr);
+    erpc_assert(MEM_BufferFree(ptr) == kStatus_MemSuccess);
 }
 
 /* Provide function for pure virtual call to avoid huge demangling code being linked in ARM GCC */

--- a/erpc_c/port/erpc_port_mqx.cpp
+++ b/erpc_c/port/erpc_port_mqx.cpp
@@ -62,7 +62,7 @@ void *erpc_malloc(size_t size)
 
 void erpc_free(void *ptr)
 {
-    _mem_free(ptr);
+    erpc_assert(_mem_free(ptr) == MQX_OK);
 }
 
 /* Provide function for pure virtual call to avoid huge demangling code being linked in ARM GCC */

--- a/erpc_c/port/erpc_port_mqx.cpp
+++ b/erpc_c/port/erpc_port_mqx.cpp
@@ -62,7 +62,10 @@ void *erpc_malloc(size_t size)
 
 void erpc_free(void *ptr)
 {
-    erpc_assert(_mem_free(ptr) == MQX_OK);
+    if (ptr != NULL)
+    {
+        erpc_assert(_mem_free(ptr) == MQX_OK);
+    }
 }
 
 /* Provide function for pure virtual call to avoid huge demangling code being linked in ARM GCC */


### PR DESCRIPTION
assertion added for functions which are returning status on freeing memory

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [X] bug
- [X] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Some functions which are freeing memory are returning statuses. These should be checked.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [ ] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
