### PR TITLE
check the buffer boundaries before reading from heap

### DIFF
--- a/erpcgen/src/templates/c_coders.template
+++ b/erpcgen/src/templates/c_coders.template
@@ -239,6 +239,9 @@ codec->write({$info.name});
 {% enddef --------------------------------------- BuiltinType %}
 
 {% def encodeBinaryType(info) -----------------  %}
+{% if source == "server" && info.size != info.maxSize %}
+erpc_assert({$info.size} <= {$info.maxSize} * sizeof({$info.mallocSizeType}));
+{% endif %}
 codec->writeBinary({% if source == "client" && info.pointerScalarTypes %}*{% endif %}{$info.size}, {$info.name});
 {% enddef --------------------------------------- BinaryType %}
 

--- a/erpcgen/test/test_length_c.yml
+++ b/erpcgen/test/test_length_c.yml
@@ -126,6 +126,7 @@ test_server.cpp:
   - not: codec->read
   - if: dir in ('out', 'inout')
     then:
+      - erpc_assert(c <= 10 * sizeof(uint8_t));
       - codec->writeBinary(c, v);
   - not: codec->write
 


### PR DESCRIPTION
# Pull request

**Choose Correct**

- [ ] bug
- [X] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Check that length that going to read from heap buffer that was allocated by the auto-generated code not exceeding the buffer length
**To Reproduce**
<!--
Steps to reproduce the behavior.
-->
Attached example code (.erpc):
[min_reproduce.txt](https://github.com/EmbeddedRPC/erpc/files/8898078/min_reproduce.txt)

reproduces (cpp code):
[min_reproduce_server.txt](https://github.com/EmbeddedRPC/erpc/files/8898087/min_reproduce_server.txt)
 I recommend to add similar use case to tests, as currently I didn't find similar tests

to make the assert pop, return ret_size bigger than 100

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->
Stuck (at least at dev flavors), probably heap corrupted
**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:ubuntu
- eRPC Version<!--[e.g. v1.9.0]-->: v1.9.0 

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
Not sure if to add enter between the assert to the write