### PR TITLE
Fixed closing arbitrator server

### DIFF
--- a/test/common/unit_test_arbitrator_app1.cpp
+++ b/test/common/unit_test_arbitrator_app1.cpp
@@ -223,8 +223,12 @@ void stopSecondSide()
 
 int32_t getResultFromSecondSide()
 {
-    increaseWaitQuit();
     return isTestPassing;
+}
+
+void testCasesAreDone(void)
+{
+    increaseWaitQuit();
 }
 
 void quitFirstInterfaceServer()

--- a/test/common/unit_test_tcp_arbitrator_server.cpp
+++ b/test/common/unit_test_tcp_arbitrator_server.cpp
@@ -188,9 +188,12 @@ void stopSecondSide()
 
 int32_t getResultFromSecondSide()
 {
-    increaseWaitQuit();
-
     return isTestPassing;
+}
+
+void testCasesAreDone(void)
+{
+    increaseWaitQuit();
 }
 
 void quitFirstInterfaceServer()

--- a/test/test_arbitrator/test_arbitrator.erpc
+++ b/test/test_arbitrator/test_arbitrator.erpc
@@ -20,6 +20,7 @@ interface FirstInterface
     firstReceiveInt() -> int32
     stopSecondSide() -> void
     getResultFromSecondSide() -> int32
+    oneway testCasesAreDone()
     oneway quitFirstInterfaceServer()
     nestedCallTest() -> int32
     @nested

--- a/test/test_arbitrator/test_arbitrator_client_impl.cpp
+++ b/test/test_arbitrator/test_arbitrator_client_impl.cpp
@@ -63,6 +63,11 @@ TEST(test_arbitrator, GetResultFromSecondSide)
     EXPECT_TRUE(getResultFromSecondSide() == 0);
 }
 
+TEST(test_arbitrator, testCasesAreDone)
+{
+    testCasesAreDone();
+}
+
 void secondSendInt(int32_t a)
 {
     numbers[i] = a;


### PR DESCRIPTION
In current situation client could hang as it's server could be closed before receiving answer. Server is used for receiving all answers.

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [x] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Hi Michal, i noticed that test_arbitrator hangs often. Based on my today debugging i think i found rootcause and solution. 
coren0 last erpc function informed second side that tests are over and we can close servers. Then other core sometimes send erpc call to stop core0 server before core0 received answer from last request.

I add new erpc function which is oneway (so no wait for answer) which will start the process with closing servers.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->
Rerun tests several times

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->
No hang

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->: ubuntu 22.04
- eRPC Version<!--[e.g. v1.9.0]-->: develop latest

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
