### PR TITLE
Fix single line comment highlighting in VSCode

### DIFF
--- a/utilities/styles/VSC/syntaxes/erpc.tmLanguage.json
+++ b/utilities/styles/VSC/syntaxes/erpc.tmLanguage.json
@@ -67,7 +67,7 @@
         },
         "comments": {
             "name": "comment.line.erpc",
-            "match": "\\\\.*"
+            "match": "//.*"
         },
         "multilineCommentsDocument": {
             "name": "comment.block.erpc",


### PR DESCRIPTION
# Pull request

**Choose Correct**

- [x] bug
- [ ] feature

**Describe the pull request**
<!--
-->
According to wiki/IDL-Reference, single line comments start with "//". 
Various example .erpc files also use the "//" style single line comment.
However, the tml language definition of single line comment in utilities/styles/VSC/syntaxes/template.tmLanguage.json starts with "\\\\".
This PR is meant to fix this.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->
1. Open folder `utilities/styles/VSC` in vscode
1. Press F5
1. Open `examples/ble/ble_gatt.erpc` or any .erpc file with single line comment

The language server is not highlighting the single line comments correctly

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->
The commented `union bleUuid_t` definition should all be green.

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->
Original:
![image](https://user-images.githubusercontent.com/40593191/177291367-27f46320-5f67-47f2-9853-0f1a92a56d50.png)
After fix:
![image](https://user-images.githubusercontent.com/40593191/177291511-38f59378-1700-4b76-afbf-2b236ea75857.png)

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->: Ubuntu 20.04 LTS
- eRPC Version<!--[e.g. v1.9.0]-->: v1.9.0

**Steps you didn't forgot to do**

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
