### PR TITLE
Compare value length to used length () in reading data from message buffer.

### DIFF
--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -343,17 +343,21 @@ void BasicCodec::readBinary(uint32_t *length, uint8_t **value)
 
     if (isStatusOk())
     {
-        if (m_cursor.getRemaining() >= *length)
+        if (m_cursor.getRemainingUsed() < *length)
+        {
+            m_status = kErpcStatus_Fail;
+        }
+        else if (m_cursor.getRemaining() < *length)
+        {
+            m_status = kErpcStatus_BufferOverrun;
+        }
+        else
         {
             // Return current pointer into buffer.
             *value = m_cursor.get();
 
             // Skip over data.
             m_cursor += (uint16_t)*length;
-        }
-        else
-        {
-            m_status = kErpcStatus_BufferOverrun;
         }
     }
     if (!isStatusOk())

--- a/erpc_c/infra/erpc_message_buffer.cpp
+++ b/erpc_c/infra/erpc_message_buffer.cpp
@@ -127,7 +127,7 @@ const uint8_t &MessageBuffer::Cursor::operator[](int index) const
 
 MessageBuffer::Cursor &MessageBuffer::Cursor::operator+=(uint16_t n)
 {
-    erpc_assert((uint16_t)(m_pos - m_buffer->get()) + n <= m_buffer->getLength());
+    erpc_assert((uint32_t)(m_pos - m_buffer->get()) + n <= m_buffer->getLength());
 
     m_pos += n;
 
@@ -136,7 +136,7 @@ MessageBuffer::Cursor &MessageBuffer::Cursor::operator+=(uint16_t n)
 
 MessageBuffer::Cursor &MessageBuffer::Cursor::operator-=(uint16_t n)
 {
-    erpc_assert((m_pos - n) >= m_buffer->get());
+    erpc_assert(((uintptr_t)m_pos >= n) && (m_pos - n) >= m_buffer->get());
 
     m_pos -= n;
 

--- a/erpc_c/infra/erpc_message_buffer.cpp
+++ b/erpc_c/infra/erpc_message_buffer.cpp
@@ -194,6 +194,7 @@ erpc_status_t MessageBuffer::Cursor::read(void *data, uint32_t length)
 erpc_status_t MessageBuffer::Cursor::write(const void *data, uint32_t length)
 {
     erpc_assert((m_pos != NULL) && ("Data buffer wasn't set to MessageBuffer." != NULL));
+    erpc_assert(m_pos == (m_buffer->get() + m_buffer->getUsed()));
 
     erpc_status_t err = kErpcStatus_Success;
 

--- a/erpc_c/infra/erpc_message_buffer.cpp
+++ b/erpc_c/infra/erpc_message_buffer.cpp
@@ -20,6 +20,13 @@ using namespace std;
 // Code
 ////////////////////////////////////////////////////////////////////////////////
 
+void MessageBuffer::setUsed(uint16_t used)
+{
+    erpc_assert(used <= m_len);
+
+    m_used = used;
+}
+
 erpc_status_t MessageBuffer::read(uint16_t offset, void *data, uint32_t length)
 {
     erpc_status_t err = kErpcStatus_Success;
@@ -102,7 +109,56 @@ void MessageBuffer::Cursor::set(MessageBuffer *buffer)
     // erpc_assert(buffer->get() && "Data buffer wasn't set to MessageBuffer.");
     // receive function should return err if it couldn't set data buffer.
     m_pos = buffer->get();
-    m_remaining = buffer->getLength();
+}
+
+uint8_t &MessageBuffer::Cursor::operator[](int index)
+{
+    erpc_assert(((m_pos + index) >= m_buffer->get()) && ((uint16_t)(m_pos - m_buffer->get()) + index <= m_buffer->getLength()));
+
+    return m_pos[index];
+}
+
+const uint8_t &MessageBuffer::Cursor::operator[](int index) const
+{
+    erpc_assert(((m_pos + index) >= m_buffer->get()) && ((uint16_t)(m_pos - m_buffer->get()) + index <= m_buffer->getLength()));
+
+    return m_pos[index];
+}
+
+MessageBuffer::Cursor &MessageBuffer::Cursor::operator+=(uint16_t n)
+{
+    erpc_assert((uint16_t)(m_pos - m_buffer->get()) + n <= m_buffer->getLength());
+
+    m_pos += n;
+
+    return *this;
+}
+
+MessageBuffer::Cursor &MessageBuffer::Cursor::operator-=(uint16_t n)
+{
+    erpc_assert((m_pos - n) >= m_buffer->get());
+
+    m_pos -= n;
+
+    return *this;
+}
+
+MessageBuffer::Cursor &MessageBuffer::Cursor::operator++(void)
+{
+    erpc_assert((uint16_t)(m_pos - m_buffer->get()) < m_buffer->getLength());
+
+    ++m_pos;
+
+    return *this;
+}
+
+MessageBuffer::Cursor &MessageBuffer::Cursor::operator--(void)
+{
+    erpc_assert(m_pos > m_buffer->get());
+
+    --m_pos;
+
+    return *this;
 }
 
 erpc_status_t MessageBuffer::Cursor::read(void *data, uint32_t length)
@@ -117,7 +173,11 @@ erpc_status_t MessageBuffer::Cursor::read(void *data, uint32_t length)
         {
             err = kErpcStatus_MemoryError;
         }
-        else if (length > m_remaining)
+        else if (length > getRemainingUsed())
+        {
+            err = kErpcStatus_Fail;
+        }
+        else if (length > getRemaining())
         {
             err = kErpcStatus_BufferOverrun;
         }
@@ -125,7 +185,6 @@ erpc_status_t MessageBuffer::Cursor::read(void *data, uint32_t length)
         {
             (void)memcpy(data, m_pos, length);
             m_pos += length;
-            m_remaining -= length;
         }
     }
 
@@ -144,7 +203,7 @@ erpc_status_t MessageBuffer::Cursor::write(const void *data, uint32_t length)
         {
             err = kErpcStatus_MemoryError;
         }
-        else if (length > m_remaining)
+        else if (length > getRemaining())
         {
             err = kErpcStatus_BufferOverrun;
         }
@@ -152,7 +211,6 @@ erpc_status_t MessageBuffer::Cursor::write(const void *data, uint32_t length)
         {
             (void)memcpy(m_pos, data, length);
             m_pos += length;
-            m_remaining -= length;
             m_buffer->setUsed(m_buffer->getUsed() + length);
         }
     }

--- a/erpc_c/infra/erpc_message_buffer.hpp
+++ b/erpc_c/infra/erpc_message_buffer.hpp
@@ -119,7 +119,7 @@ public:
      *
      * @param[in] used Length of used space of buffer.
      */
-    void setUsed(uint16_t used) { m_used = used; }
+    void setUsed(uint16_t used);
 
     /*!
      * @brief This function read data from local buffer.
@@ -197,7 +197,6 @@ public:
         Cursor(void)
         : m_buffer(NULL)
         , m_pos(NULL)
-        , m_remaining(0)
         {
         }
 
@@ -208,10 +207,9 @@ public:
          *
          * @param[in] buffer MessageBuffer for sending/receiving.
          */
-        Cursor(MessageBuffer *buffer)
+        explicit Cursor(MessageBuffer *buffer)
         : m_buffer(buffer)
         , m_pos(buffer->get())
-        , m_remaining(buffer->getLength())
         {
         }
 
@@ -245,7 +243,14 @@ public:
          *
          * @return Remaining free space in current buffer.
          */
-        uint16_t getRemaining(void) const { return m_remaining; }
+        uint16_t getRemaining(void) const { return m_buffer->getLength() - (uint16_t)(m_pos - m_buffer->get()); }
+
+        /*!
+         * @brief Return remaining space from used of current buffer.
+         *
+         * @return Remaining space from used of current buffer.
+         */
+        uint16_t getRemainingUsed(void) const { return m_buffer->getUsed() - (uint16_t)(m_pos - m_buffer->get()); }
 
         /*!
          * @brief Read data from current buffer.
@@ -284,14 +289,14 @@ public:
          *
          * @param[in] index Index in buffer.
          */
-        uint8_t &operator[](int index) { return m_pos[index]; }
+        uint8_t &operator[](int index);
 
         /*!
          * @brief Array operator return value of buffer at given index.
          *
          * @param[in] index Index in buffer.
          */
-        const uint8_t &operator[](int index) const { return m_pos[index]; }
+        const uint8_t &operator[](int index) const;
 
         /*!
          * @brief Sum operator return local buffer.
@@ -300,12 +305,7 @@ public:
          *
          * @return Current cursor instance.
          */
-        Cursor &operator+=(uint16_t n)
-        {
-            m_pos += n;
-            m_remaining -= n;
-            return *this;
-        }
+        Cursor &operator+=(uint16_t n);
 
         /*!
          * @brief Substract operator return local buffer.
@@ -314,41 +314,25 @@ public:
          *
          * @return Current cursor instance.
          */
-        Cursor &operator-=(uint16_t n)
-        {
-            m_pos -= n;
-            m_remaining += n;
-            return *this;
-        }
+        Cursor &operator-=(uint16_t n);
 
         /*!
          * @brief Sum +1 operator.
          *
          * @return Current cursor instance.
          */
-        Cursor &operator++(void)
-        {
-            ++m_pos;
-            --m_remaining;
-            return *this;
-        }
+        Cursor &operator++(void);
 
         /*!
          * @brief Substract -1 operator.
          *
          * @return Current cursor instance.
          */
-        Cursor &operator--(void)
-        {
-            --m_pos;
-            ++m_remaining;
-            return *this;
-        }
+        Cursor &operator--(void);
 
     private:
         MessageBuffer *m_buffer; /*!< Buffer for reading or writing data. */
         uint8_t *m_pos;          /*!< Position in buffer, where it last write/read */
-        uint16_t m_remaining;    /*!< Remaining space in buffer. */
     };
 
 private:


### PR DESCRIPTION

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [X] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
This should cover cases when we will try read more data that we received.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
