### PR TITLE
Add TCP_NODELAY option to python

### DIFF
--- a/erpc_python/erpc/transport.py
+++ b/erpc_python/erpc/transport.py
@@ -142,12 +142,14 @@ class TCPTransport(FramedTransport):
             self._serverSockEventStart = threading.Event()
         else:
             self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
             self._sock.connect((self._host, self._port))
 
     def _serve(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setblocking(1)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
         s.bind((self._host, self._port))
         s.listen(5)
 


### PR DESCRIPTION
Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [ ] bug
- [X] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Tcp communication should be faster

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
