### PR TITLE
Replace EXPECT_TRUE with EXPECT_EQ

### DIFF
--- a/test/common/gtestListener.hpp
+++ b/test/common/gtestListener.hpp
@@ -26,9 +26,9 @@ private:
     {
         int serverAlloc = getServerAllocated();
 
-        EXPECT_TRUE(MyAlloc::allocated() == 0)
+        EXPECT_EQ(MyAlloc::allocated(), 0)
             << "Leaked (on client side) : " << MyAlloc::allocated() << " unit(s) need be freed!";
-        EXPECT_TRUE(serverAlloc == 0) << "Leaked (on server side) : " << serverAlloc << " unit(s) need be freed!";
+        EXPECT_EQ(serverAlloc, 0) << "Leaked (on server side) : " << serverAlloc << " unit(s) need be freed!";
         MyAlloc::allocated(0);
     }
 };

--- a/test/test_annotations/test_annotations_client_impl.cpp
+++ b/test/test_annotations/test_annotations_client_impl.cpp
@@ -15,18 +15,18 @@
 
 TEST(test_annotations, AnnotationServiceID)
 {
-    EXPECT_TRUE(5 == kAnnotateTest_service_id);
+    EXPECT_EQ(kAnnotateTest_service_id, 5);
 }
 
 TEST(test_annotations, IncludeAnnotationCheck)
 {
-    EXPECT_TRUE(5 == addOne(4));
+    EXPECT_EQ(addOne(4), 5);
 
     includedInt_t testInt = 5;
-    EXPECT_TRUE(5 == testInt);
+    EXPECT_EQ(testInt, 5);
 }
 
 TEST(test_annotations, testIfMyIntAndConstExist)
 {
-    EXPECT_TRUE(i == testIfMyIntAndConstExist(i));
+    EXPECT_EQ(i, testIfMyIntAndConstExist(i));
 }

--- a/test/test_arbitrator/test_arbitrator_client_impl.cpp
+++ b/test/test_arbitrator/test_arbitrator_client_impl.cpp
@@ -32,7 +32,7 @@ TEST(test_arbitrator, FirstSendReceiveInt)
     for (int i = number - 1; i >= 0; i--)
     {
         int b = firstReceiveInt();
-        EXPECT_TRUE(i == b);
+        EXPECT_EQ(i, b);
     }
 }
 
@@ -45,7 +45,7 @@ TEST(test_arbitrator, FirstSendReceiveInt2)
     for (int i = number - 1; i >= 0; i--)
     {
         int b = firstReceiveInt();
-        EXPECT_TRUE(i == b);
+        EXPECT_EQ(i, b);
     }
 }
 
@@ -55,12 +55,12 @@ TEST(test_arbitrator, NestedCallTest)
     while (!enabled)
     {
     };
-    EXPECT_TRUE(nestedCallTest() == nestedCallsCount * 2 - 1);
+    EXPECT_EQ(nestedCallTest(), nestedCallsCount * 2 - 1);
 }
 
 TEST(test_arbitrator, GetResultFromSecondSide)
 {
-    EXPECT_TRUE(getResultFromSecondSide() == 0);
+    EXPECT_EQ(getResultFromSecondSide(), 0);
 }
 
 TEST(test_arbitrator, testCasesAreDone)

--- a/test/test_arrays/test_arrays_client_impl.cpp
+++ b/test/test_arrays/test_arrays_client_impl.cpp
@@ -30,7 +30,7 @@ TEST(test_arrays, sendReceivedInt32)
 
     for (uint32_t i = 0; i < array_count; ++i)
     {
-        EXPECT_TRUE(send_array[i] == (*received_array)[i]);
+        EXPECT_EQ(send_array[i], (*received_array)[i]);
     }
     erpc_free(received_array);
 }
@@ -53,7 +53,7 @@ TEST(test_arrays, sendReceived2Int32)
     {
         for (uint32_t j = 0; j < 10; ++j)
         {
-            EXPECT_TRUE(send_array[i][j] == (*received_array)[i][j]);
+            EXPECT_EQ(send_array[i][j], (*received_array)[i][j]);
         }
     }
     erpc_free(received_array);
@@ -130,7 +130,7 @@ TEST(test_arrays, sendReceivedEnum)
 
     for (uint32_t i = 0; i < array_count; ++i)
     {
-        EXPECT_TRUE(send_array[i] == (*received_array)[i]);
+        EXPECT_EQ(send_array[i], (*received_array)[i]);
     }
     erpc_free(received_array);
 }
@@ -154,7 +154,7 @@ TEST(test_arrays, sendReceived2Enum)
     {
         for (uint32_t j = 0; j < 3; ++j)
         {
-            EXPECT_TRUE(send_array[i][j] == (*received_array)[i][j]);
+            EXPECT_EQ(send_array[i][j], (*received_array)[i][j]);
         }
     }
     erpc_free(received_array);
@@ -185,7 +185,7 @@ TEST(test_arrays, sendReceivedList)
         int32_t *list_r = (*received_array)[i].elements;
         for (uint32_t j = 0; j < elements_count; ++j)
         {
-            EXPECT_TRUE(*list_r == *list_s);
+            EXPECT_EQ(*list_r, *list_s);
             list_r++;
             list_s++;
         }
@@ -224,7 +224,7 @@ TEST(test_arrays, sendReceived2List)
             int32_t *list_r = (*received_array)[k][i].elements;
             for (uint32_t j = 0; j < elements_count; ++j)
             {
-                EXPECT_TRUE(*list_r == *list_s);
+                EXPECT_EQ(*list_r, *list_s);
                 list_r++;
                 list_s++;
             }
@@ -250,7 +250,7 @@ TEST(test_arrays, sendReceivedInt32Type)
 
     for (uint32_t i = 0; i < array_count; ++i)
     {
-        EXPECT_TRUE(send_array[i] == (*received_array)[i]);
+        EXPECT_EQ(send_array[i], (*received_array)[i]);
     }
     erpc_free(received_array);
 }
@@ -274,7 +274,7 @@ TEST(test_arrays, sendReceived2Int32Type)
     {
         for (uint32_t j = 0; j < 10; ++j)
         {
-            EXPECT_TRUE(send_array[i][j] == (*received_array)[i][j]);
+            EXPECT_EQ(send_array[i][j], (*received_array)[i][j]);
         }
     }
     erpc_free(received_array);
@@ -351,7 +351,7 @@ TEST(test_arrays, sendReceivedEnumType)
 
     for (uint32_t i = 0; i < array_count; ++i)
     {
-        EXPECT_TRUE(send_array[i] == (*received_array)[i]);
+        EXPECT_EQ(send_array[i], (*received_array)[i]);
     }
     erpc_free(received_array);
 }
@@ -375,7 +375,7 @@ TEST(test_arrays, sendReceived2EnumType)
     {
         for (uint32_t j = 0; j < 3; ++j)
         {
-            EXPECT_TRUE(send_array[i][j] == (*received_array)[i][j]);
+            EXPECT_EQ(send_array[i][j], (*received_array)[i][j]);
         }
     }
     erpc_free(received_array);
@@ -397,8 +397,8 @@ TEST(test_arrays, sendReceivedStructType)
 
     for (uint32_t i = 0; i < array_count; ++i)
     {
-        EXPECT_TRUE(send_array[i].m == (*received_array)[i].m);
-        EXPECT_TRUE(send_array[i].n == (*received_array)[i].n);
+        EXPECT_EQ(send_array[i].m, (*received_array)[i].m);
+        EXPECT_EQ(send_array[i].n, (*received_array)[i].n);
     }
     erpc_free(received_array);
 }
@@ -423,8 +423,8 @@ TEST(test_arrays, sendReceived2StructType)
     {
         for (uint32_t j = 0; j < 3; ++j)
         {
-            EXPECT_TRUE(send_array[i][j].m == (*received_array)[i][j].m);
-            EXPECT_TRUE(send_array[i][j].n == (*received_array)[i][j].n);
+            EXPECT_EQ(send_array[i][j].m, (*received_array)[i][j].m);
+            EXPECT_EQ(send_array[i][j].n, (*received_array)[i][j].n);
         }
     }
     erpc_free(received_array);
@@ -455,7 +455,7 @@ TEST(test_arrays, sendReceivedListType)
         int32_t *list_r = (*received_array)[i].elements;
         for (uint32_t j = 0; j < elements_count; ++j)
         {
-            EXPECT_TRUE(*list_r == *list_s);
+            EXPECT_EQ(*list_r, *list_s);
             list_r++;
             list_s++;
         }
@@ -494,7 +494,7 @@ TEST(test_arrays, sendReceived2ListType)
             int32_t *list_r = (*received_array)[k][i].elements;
             for (uint32_t j = 0; j < elements_count; ++j)
             {
-                EXPECT_TRUE(*list_r == *list_s);
+                EXPECT_EQ(*list_r, *list_s);
                 list_r++;
                 list_s++;
             }
@@ -545,18 +545,18 @@ TEST(test_arrays, sendReceiveStruct)
 
     for (uint32_t k = 0; k < 2; ++k)
     {
-        EXPECT_TRUE(send_struct[k].number == (*received_struct)[k].number);
+        EXPECT_EQ(send_struct[k].number, (*received_struct)[k].number);
         EXPECT_STREQ(send_struct[k].text, (*received_struct)[k].text);
         erpc_free(send_struct[k].text);
         erpc_free((*received_struct)[k].text);
-        EXPECT_TRUE(send_struct[k].color == (*received_struct)[k].color);
-        EXPECT_TRUE(send_struct[k].c.m == (*received_struct)[k].c.m);
-        EXPECT_TRUE(send_struct[k].c.n == (*received_struct)[k].c.n);
+        EXPECT_EQ(send_struct[k].color, (*received_struct)[k].color);
+        EXPECT_EQ(send_struct[k].c.m, (*received_struct)[k].c.m);
+        EXPECT_EQ(send_struct[k].c.n, (*received_struct)[k].c.n);
 
-        EXPECT_TRUE(send_struct[k].list_numbers.elementsCount == (*received_struct)[k].list_numbers.elementsCount);
+        EXPECT_EQ(send_struct[k].list_numbers.elementsCount, (*received_struct)[k].list_numbers.elementsCount);
         for (uint32_t i = 0; i < 5; ++i)
         {
-            EXPECT_TRUE(send_struct[k].list_numbers.elements[i] == (*received_struct)[k].list_numbers.elements[i]);
+            EXPECT_EQ(send_struct[k].list_numbers.elements[i], (*received_struct)[k].list_numbers.elements[i]);
             EXPECT_STREQ(send_struct[k].list_text.elements[i], (*received_struct)[k].list_text.elements[i]);
             erpc_free(send_struct[k].list_text.elements[i]);
             erpc_free((*received_struct)[k].list_text.elements[i]);
@@ -568,7 +568,7 @@ TEST(test_arrays, sendReceiveStruct)
 
         for (uint32_t i = 0; i < 5; ++i)
         {
-            EXPECT_TRUE(send_struct[k].array_numbers[i] == (*received_struct)[k].array_numbers[i]);
+            EXPECT_EQ(send_struct[k].array_numbers[i], (*received_struct)[k].array_numbers[i]);
             EXPECT_STREQ(send_struct[k].array_text[i], (*received_struct)[k].array_text[i]);
             erpc_free(send_struct[k].array_text[i]);
             erpc_free((*received_struct)[k].array_text[i]);
@@ -622,20 +622,20 @@ TEST(test_arrays, sendReceive2Struct)
     {
         for (uint32_t l = 0; l < 1; ++l)
         {
-            EXPECT_TRUE(send_struct[k][l].number == (*received_struct)[k][l].number);
+            EXPECT_EQ(send_struct[k][l].number, (*received_struct)[k][l].number);
             EXPECT_STREQ(send_struct[k][l].text, (*received_struct)[k][l].text);
             erpc_free(send_struct[k][l].text);
             erpc_free((*received_struct)[k][l].text);
-            EXPECT_TRUE(send_struct[k][l].color == (*received_struct)[k][l].color);
-            EXPECT_TRUE(send_struct[k][l].c.m == (*received_struct)[k][l].c.m);
-            EXPECT_TRUE(send_struct[k][l].c.n == (*received_struct)[k][l].c.n);
+            EXPECT_EQ(send_struct[k][l].color, (*received_struct)[k][l].color);
+            EXPECT_EQ(send_struct[k][l].c.m, (*received_struct)[k][l].c.m);
+            EXPECT_EQ(send_struct[k][l].c.n, (*received_struct)[k][l].c.n);
 
-            EXPECT_TRUE(send_struct[k][l].list_numbers.elementsCount ==
-                        (*received_struct)[k][l].list_numbers.elementsCount);
+            EXPECT_EQ(send_struct[k][l].list_numbers.elementsCount,
+                      (*received_struct)[k][l].list_numbers.elementsCount);
             for (uint32_t i = 0; i < 5; ++i)
             {
-                EXPECT_TRUE(send_struct[k][l].list_numbers.elements[i] ==
-                            (*received_struct)[k][l].list_numbers.elements[i]);
+                EXPECT_EQ(send_struct[k][l].list_numbers.elements[i],
+                          (*received_struct)[k][l].list_numbers.elements[i]);
                 EXPECT_STREQ(send_struct[k][l].list_text.elements[i], (*received_struct)[k][l].list_text.elements[i]);
                 erpc_free(send_struct[k][l].list_text.elements[i]);
                 erpc_free((*received_struct)[k][l].list_text.elements[i]);
@@ -647,7 +647,7 @@ TEST(test_arrays, sendReceive2Struct)
 
             for (uint32_t i = 0; i < 5; ++i)
             {
-                EXPECT_TRUE(send_struct[k][l].array_numbers[i] == (*received_struct)[k][l].array_numbers[i]);
+                EXPECT_EQ(send_struct[k][l].array_numbers[i], (*received_struct)[k][l].array_numbers[i]);
                 EXPECT_STREQ(send_struct[k][l].array_text[i], (*received_struct)[k][l].array_text[i]);
                 erpc_free(send_struct[k][l].array_text[i]);
                 erpc_free((*received_struct)[k][l].array_text[i]);
@@ -683,9 +683,9 @@ TEST(test_arrays, test_array_allDirection)
 
     for (uint32_t i = 0; i < 5; ++i)
     {
-        EXPECT_TRUE(a[i] == pA[i]);
-        EXPECT_TRUE(b[i] == pB[i]);
-        EXPECT_TRUE(c[i] == pC[i]);
-        EXPECT_TRUE(d[i] == pD[i]);
+        EXPECT_EQ(a[i], pA[i]);
+        EXPECT_EQ(b[i], pB[i]);
+        EXPECT_EQ(c[i], pC[i]);
+        EXPECT_EQ(d[i], pD[i]);
     }
 }

--- a/test/test_binary/test_binary_client_impl.cpp
+++ b/test/test_binary/test_binary_client_impl.cpp
@@ -27,7 +27,7 @@ using namespace std;
     result = sendReceiveBinary(&send);
     for (uint8_t i = 0; i < result->dataLength; ++i)
     {
-        EXPECT_TRUE(send.data[i] == result->data[i]);
+        EXPECT_EQ(send.data[i] , result->data[i]);
     }
     free(send.data);
     free(result->data);
@@ -53,7 +53,7 @@ TEST(test_binary, sendBinary)
     result = receiveBinary();
     for (uint8_t i = 0; i < result->dataLength; ++i)
     {
-        EXPECT_TRUE(i == result->data[i]);
+        EXPECT_EQ(i , result->data[i]);
     }
     free(result->data);
     free(result);
@@ -80,7 +80,7 @@ TEST(test_binary, test_binary_allDirection)
 
     for (uint8_t i = 0; i < 5; ++i)
     {
-        EXPECT_TRUE(e.data[i] == a.data[i] * b.data[i]);
+        EXPECT_EQ(e.data[i], a.data[i] * b.data[i]);
     }
 
     erpc_free(a.data);
@@ -111,9 +111,9 @@ TEST(test_binary, test_binary_allDirection)
 
     for (uint8_t i = 0; i < 5; ++i)
     {
-        EXPECT_TRUE(a.data[i] == c.data[i]);
-        EXPECT_TRUE(b.data[i] == d->data[i]);
-        EXPECT_TRUE(e.data[i] == 4 * i);
+        EXPECT_EQ(a.data[i] , c.data[i]);
+        EXPECT_EQ(b.data[i] , d->data[i]);
+        EXPECT_EQ(e.data[i] , 4 * i);
     }
 
     free(a.data);

--- a/test/test_builtin/test_builtin_client_impl.cpp
+++ b/test/test_builtin/test_builtin_client_impl.cpp
@@ -28,7 +28,7 @@ TEST(test_builtin, test_int32_in_out)
     int32_t c;
     test_int32_in(int32A);
     test_int32_out(&c);
-    EXPECT_TRUE(int32A == c);
+    EXPECT_EQ(int32A, c);
 }
 
 TEST(test_builtin, test_int32_inout)
@@ -37,7 +37,7 @@ TEST(test_builtin, test_int32_inout)
     for (int32_t i = -5; i <= 5; ++i)
     {
         test_int32_inout(&e);
-        EXPECT_TRUE(i == e);
+        EXPECT_EQ(i, e);
     }
 }
 
@@ -46,7 +46,7 @@ TEST(test_builtin, test_int32_return)
     test_int32_in(int32A);
     test_int32_in2(int32B);
     int32_t r = test_int32_return();
-    EXPECT_TRUE(int32A * int32B == r);
+    EXPECT_EQ(int32A * int32B, r);
 }
 
 TEST(test_builtin, test_int32_allDirection)
@@ -56,9 +56,9 @@ TEST(test_builtin, test_int32_allDirection)
 
     int32_t r = test_int32_allDirection(int32A, int32B, &c, &e);
 
-    EXPECT_TRUE(c == int32A);
-    EXPECT_TRUE(14 == e);
-    EXPECT_TRUE(int32A * int32B == r);
+    EXPECT_EQ(c, int32A);
+    EXPECT_EQ(14, e);
+    EXPECT_EQ(int32A * int32B, r);
 }
 
 TEST(test_builtin, test_float_inout)
@@ -66,7 +66,7 @@ TEST(test_builtin, test_float_inout)
     float a = 3.14;
     float b;
     test_float_inout(a, &b);
-    EXPECT_TRUE(a == b);
+    EXPECT_EQ(a, b);
 }
 
 TEST(test_builtin, test_double_inout)
@@ -74,7 +74,7 @@ TEST(test_builtin, test_double_inout)
     double a = 3.14;
     double b;
     test_double_inout(a, &b);
-    EXPECT_TRUE(a == b);
+    EXPECT_EQ(a, b);
 }
 
 TEST(test_builtin, test_string_in_out)
@@ -133,16 +133,16 @@ TEST(test_builtin, test_string_allDirection)
     char *r = test_string_empty(a, b, c, &d, e);
 
     EXPECT_STREQ("", c);
-    EXPECT_TRUE(d == NULL);
+    EXPECT_EQ(d , NULL);
     EXPECT_STREQ("", e);
-    EXPECT_TRUE(r == NULL);
+    EXPECT_EQ(r , NULL);
 }*/
 
 TEST(test_builtin, StringParamTest1)
 {
     const char *str = "Hello World!";
     int32_t result = sendHello(str);
-    EXPECT_TRUE(result == 0);
+    EXPECT_EQ(result, 0);
 }
 
 TEST(test_builtin, StringParamTest2)
@@ -150,7 +150,7 @@ TEST(test_builtin, StringParamTest2)
     const char *str1 = "String one.";
     const char *str2 = "String two.";
     int32_t result = sendTwoStrings(str1, str2);
-    EXPECT_TRUE(result == 0);
+    EXPECT_EQ(result, 0);
 }
 
 TEST(test_builtin, StringReturnTest1)

--- a/test/test_callbacks/test_callbacks_client_impl.cpp
+++ b/test/test_callbacks/test_callbacks_client_impl.cpp
@@ -42,14 +42,14 @@ TEST(test_callbacks, In_Out_withoutTable)
 TEST(test_callbacks, Common_Callback)
 {
     callback3_t callback = my_add;
-    EXPECT_TRUE(12 == myFun3(callback, 9, 3));
+    EXPECT_EQ(12, myFun3(callback, 9, 3));
 
     callback = my_sub;
-    EXPECT_TRUE(6 == myFun3(callback, 9, 3));
+    EXPECT_EQ(6, myFun3(callback, 9, 3));
 
     callback = my_mul;
-    EXPECT_TRUE(27 == myFun3(callback, 9, 3));
+    EXPECT_EQ(27, myFun3(callback, 9, 3));
 
     callback = my_div;
-    EXPECT_TRUE(3 == myFun3(callback, 9, 3));
+    EXPECT_EQ(3, myFun3(callback, 9, 3));
 }

--- a/test/test_const/test_const_client_impl.cpp
+++ b/test/test_const/test_const_client_impl.cpp
@@ -15,13 +15,13 @@
 
 TEST(test_const, CheckConsts)
 {
-    EXPECT_TRUE(a == 3);
-    EXPECT_TRUE((float)b == (float)3.14);
+    EXPECT_EQ(a, 3);
+    EXPECT_EQ((float)b, (float)3.14);
     EXPECT_STREQ("feedbabe", c);
-    EXPECT_TRUE((float)d == (float)3.14);
-    EXPECT_TRUE(x == 11);
-    EXPECT_TRUE(y == 20);
+    EXPECT_EQ((float)d, (float)3.14);
+    EXPECT_EQ(x, 11);
+    EXPECT_EQ(y, 20);
 
-    EXPECT_TRUE(mass == 100);
-    EXPECT_TRUE(accel == (float)-9.8);
+    EXPECT_EQ(mass, 100);
+    EXPECT_EQ(accel, (float)-9.8);
 }

--- a/test/test_enums/test_enums_client_impl.cpp
+++ b/test/test_enums/test_enums_client_impl.cpp
@@ -21,21 +21,21 @@ TEST(test_enum, test_enumColor_in_out)
     enumColor c;
     test_enumColor_in(enumColorA);
     test_enumColor_out(&c);
-    EXPECT_TRUE(enumColorA == c);
+    EXPECT_EQ(enumColorA, c);
 }
 
 TEST(test_enum, test_enumColor_inout)
 {
     enumColor e = enumColorA;
     test_enumColor_inout(&e);
-    EXPECT_TRUE(enumColorB == e);
+    EXPECT_EQ(enumColorB, e);
 }
 
 TEST(test_enum, test_enumColor_return)
 {
     test_enumColor_in(enumColorB);
     enumColor r = test_enumColor_return();
-    EXPECT_TRUE(enumColorA == r);
+    EXPECT_EQ(enumColorA, r);
 }
 
 TEST(test_enum, test_enumColor_allDirection)
@@ -45,9 +45,9 @@ TEST(test_enum, test_enumColor_allDirection)
 
     enumColor r = test_enumColor_allDirection(enumColorA, enumColorB, &c, &e);
 
-    EXPECT_TRUE(enumColorA == c);
-    EXPECT_TRUE(enumColorB == e);
-    EXPECT_TRUE(enumColorA == r);
+    EXPECT_EQ(enumColorA, c);
+    EXPECT_EQ(enumColorB, e);
+    EXPECT_EQ(enumColorA, r);
 }
 
 TEST(test_enum, test_enumColor2_allDirection)
@@ -59,9 +59,9 @@ TEST(test_enum, test_enumColor2_allDirection)
 
     enumColor2 r = test_enumColor2_allDirection(a, b, &c, &e);
 
-    EXPECT_TRUE(a == c);
-    EXPECT_TRUE(b == e);
-    EXPECT_TRUE(a == r);
+    EXPECT_EQ(a, c);
+    EXPECT_EQ(b, e);
+    EXPECT_EQ(a, r);
 }
 
 TEST(test_enum, test_enumErrorCode_allDirection)
@@ -73,7 +73,7 @@ TEST(test_enum, test_enumErrorCode_allDirection)
 
     enumErrorCode r = test_enumErrorCode_allDirection(a, b, &c, &e);
 
-    EXPECT_TRUE(a == c);
-    EXPECT_TRUE(b == e);
-    EXPECT_TRUE(a == r);
+    EXPECT_EQ(a, c);
+    EXPECT_EQ(b, e);
+    EXPECT_EQ(a, r);
 }

--- a/test/test_lists/test_lists_client_impl.cpp
+++ b/test/test_lists/test_lists_client_impl.cpp
@@ -35,7 +35,7 @@ TEST(test_list, SendReceivedInt32)
     int32_t *list_r = received_list->elements;
     for (uint32_t i = 0; i < received_list->elementsCount; ++i)
     {
-        EXPECT_TRUE(*list_r / 2 == *list_s);
+        EXPECT_EQ(*list_r / 2, *list_s);
         ++list_s;
         ++list_r;
     }
@@ -52,7 +52,7 @@ TEST(test_list, sendReceiveZeroSize)
 
     received_list = sendReceivedInt32(&send_list);
 
-    EXPECT_TRUE(received_list->elementsCount == 0);
+    EXPECT_EQ(received_list->elementsCount , 0);
 
     erpc_free(received_list->elements);
     erpc_free(received_list);
@@ -88,7 +88,7 @@ TEST(test_list, SendReceived2Int32)
         list_r = list_int32_1_t_r->elements;
         for (uint32_t j = 0; j < list_int32_1_t_r->elementsCount; ++j)
         {
-            EXPECT_TRUE((*list_r) / 2 == *list_s);
+            EXPECT_EQ((*list_r) / 2 , *list_s);
             ++list_s;
             ++list_r;
         }
@@ -122,7 +122,7 @@ TEST(test_list, SendReceived2Int32)
 //     int32_t *list_r = received_list;
 //     for (uint32_t i = 0; i < listSize; ++i)
 //     {
-//         EXPECT_TRUE(*list_r / 2 == *list_s);
+//         EXPECT_EQ(*list_r / 2 , *list_s);
 //         ++list_s;
 //         ++list_r;
 //     }
@@ -150,7 +150,7 @@ TEST(test_list, SendReceived2Int32)
 //     int32_t *list_r = received_list;
 //     for (uint32_t i = 0; i < listSize; ++i)
 //     {
-//         EXPECT_TRUE(*list_r / 2 == *list_s);
+//         EXPECT_EQ(*list_r / 2 , *list_s);
 //         ++list_s;
 //         ++list_r;
 //     }
@@ -173,7 +173,7 @@ TEST(test_list, SendReceivedEnum)
     enumColor *list_r = received_list->elements;
     for (uint32_t i = 0; i < received_list->elementsCount; ++i)
     {
-        EXPECT_TRUE(*list_r == *list_s);
+        EXPECT_EQ(*list_r, *list_s);
         ++list_s;
         ++list_r;
     }
@@ -224,7 +224,7 @@ TEST(test_list, SendReceived2Enum)
         list_r = list_enumColor_1_t_r->elements;
         for (uint32_t j = 0; j < list_enumColor_1_t_r->elementsCount; ++j)
         {
-            EXPECT_TRUE(*list_r == *list_s);
+            EXPECT_EQ(*list_r, *list_s);
             ++list_s;
             ++list_r;
         }
@@ -257,8 +257,8 @@ TEST(test_list, SendReceivedStruct)
     C *list_r = received_list->elements;
     for (uint32_t i = 0; i < received_list->elementsCount; ++i)
     {
-        EXPECT_TRUE((list_r->m) / 2 == list_s->m);
-        EXPECT_TRUE((list_r->n) / 2 == list_s->n);
+        EXPECT_EQ((list_r->m) / 2, list_s->m);
+        EXPECT_EQ((list_r->n) / 2, list_s->n);
         ++list_s;
         ++list_r;
     }
@@ -298,8 +298,8 @@ TEST(test_list, SendReceived2Struct)
         list_r = list_int32_1_t_r->elements;
         for (uint32_t j = 0; j < list_int32_1_t_r->elementsCount; ++j)
         {
-            EXPECT_TRUE(list_r->m / 2 == list_s->m);
-            EXPECT_TRUE(list_r->n / 2 == list_s->n);
+            EXPECT_EQ(list_r->m / 2, list_s->m);
+            EXPECT_EQ(list_r->n / 2, list_s->n);
             ++list_s;
             ++list_r;
         }
@@ -431,9 +431,9 @@ TEST(test_list, test_list_allDirection)
     e_list_e = expect_list_e->elements;
     for (uint32_t i = 0; i < send_list_a->elementsCount; ++i)
     {
-        EXPECT_TRUE(*s_list_a == *e_list_a);
-        EXPECT_TRUE(*s_list_b == *e_list_b);
-        EXPECT_TRUE(*s_list_e == *e_list_e);
+        EXPECT_EQ(*s_list_a, *e_list_a);
+        EXPECT_EQ(*s_list_b, *e_list_b);
+        EXPECT_EQ(*s_list_e, *e_list_e);
         ++s_list_a;
         ++s_list_b;
         ++s_list_e;
@@ -466,7 +466,7 @@ TEST(test_list, testLengthAnnotation)
         ++list_ptr;
     }
     int32_t result = testLengthAnnotation(list, length);
-    EXPECT_TRUE(result == 1);
+    EXPECT_EQ(result, 1);
     erpc_free(list);
 }
 
@@ -480,7 +480,7 @@ TEST(test_list, testLengthAnnotationInStruct)
         myListStruct.myList[i] = (int32_t)i + 1;
     }
     int32_t result = testLengthAnnotationInStruct(&myListStruct);
-    EXPECT_TRUE(result == 10);
+    EXPECT_EQ(result, 10);
     erpc_free(myListStruct.myList);
 }
 
@@ -494,10 +494,10 @@ TEST(test_list, returnSentStructLengthAnnotation)
         myListStruct.myList[i] = (int32_t)i + 1;
     }
     listStruct *returnStruct = returnSentStructLengthAnnotation(&myListStruct);
-    EXPECT_TRUE(myListStruct.len == returnStruct->len);
+    EXPECT_EQ(myListStruct.len, returnStruct->len);
     for (unsigned int i = 0; i < returnStruct->len; ++i)
     {
-        EXPECT_TRUE(myListStruct.myList[i] == returnStruct->myList[i]);
+        EXPECT_EQ(myListStruct.myList[i], returnStruct->myList[i]);
     }
     erpc_free(myListStruct.myList);
     erpc_free(returnStruct->myList);
@@ -532,7 +532,7 @@ TEST(test_list, sendGapAdvertisingData)
 
     int32_t result = sendGapAdvertisingData(&ad);
 
-    EXPECT_TRUE(33 == result);
+    EXPECT_EQ(33, result);
 
     erpc_free(ad1.aData);
     erpc_free(ad2.aData);

--- a/test/test_shared/test_shared_client_impl.cpp
+++ b/test/test_shared/test_shared_client_impl.cpp
@@ -17,7 +17,7 @@ TEST(test_shared, sendReceiveBaseSharedStruct)
     BaseSharedStruct sm = { 4, 5 };
     BaseSharedStruct *_sm;
     _sm = sendReceiveBaseSharedStruct(&sm);
-    EXPECT_TRUE(_sm == &sm);
+    EXPECT_EQ(_sm , &sm);
 }
 
 TEST(test_shared, inoutBaseSharedStruct)
@@ -25,26 +25,26 @@ TEST(test_shared, inoutBaseSharedStruct)
     BaseSharedStruct sm = { 4, 5 };
     BaseSharedStruct *_sm = &sm;
     inoutBaseSharedStruct(&_sm);
-    EXPECT_TRUE(_sm == &sm);
+    EXPECT_EQ(_sm , &sm);
 }
 
 /*TEST(test_shared, inoutStruct1)
 {
     SharedStructMember sm = {4, 5};
     pB = sendReceiveInt(a);
-    EXPECT_TRUE(b == pB);
+    EXPECT_EQ(b , pB);
 }
 
 TEST(test_shared, inoutStruct2)
 {
     Colors a = green, pB, b = blue;
     pB = sendReceiveEnum(a);
-    EXPECT_TRUE((int32_t)b == (int32_t)pB);
+    EXPECT_EQ((int32_t)b , (int32_t)pB);
 }
 
 TEST(test_shared, inoutStruct3)
 {
     Colors a = green, pB, b = blue;
     pB = sendReceiveEnum(a);
-    EXPECT_TRUE((int32_t)b == (int32_t)pB);
+    EXPECT_EQ((int32_t)b , (int32_t)pB);
 }*/

--- a/test/test_struct/test_struct_client_impl.cpp
+++ b/test/test_struct/test_struct_client_impl.cpp
@@ -20,35 +20,35 @@ using namespace std;
 TEST(test_struct, GetMember1)
 {
     C c = { 4, 5 };
-    EXPECT_TRUE(4 == getMember(&c));
+    EXPECT_EQ(4, getMember(&c));
 }
 
 TEST(test_struct, NestedStruct1)
 {
     C c = { 4, 5 };
     D d = { c };
-    EXPECT_TRUE(4 == sendNestedStruct(&d));
+    EXPECT_EQ(4, sendNestedStruct(&d));
 }
 
 TEST(test_struct, ReturnStruct1)
 {
     B *b;
     b = returnStruct(3.14, 2.71828);
-    EXPECT_TRUE((float)b->x == (float)3.14);
-    EXPECT_TRUE((float)b->y == (float)2.71828);
+    EXPECT_EQ((float)b->x, (float)3.14);
+    EXPECT_EQ((float)b->y, (float)2.71828);
     erpc_free(b);
 }
 
 TEST(test_struct, SendIntSizes)
 {
     F f = { (int8_t)0xFF, (int16_t)0xFFFF, (int32_t)0xFFFFFFFF, (int64_t)0xFFFFFFFFFFFFFFFF };
-    EXPECT_TRUE(0 == sendManyInts(&f));
+    EXPECT_EQ(0, sendManyInts(&f));
 }
 
 TEST(test_struct, SendUnsignedIntSizes)
 {
     G g = { 0xFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFF };
-    EXPECT_TRUE(0 == sendManyUInts(&g));
+    EXPECT_EQ(0, sendManyUInts(&g));
 }
 
 TEST(test_struct, GetMember2)
@@ -57,8 +57,8 @@ TEST(test_struct, GetMember2)
     B b = { 3.14, 2.71828 };
     A a = { b, c };
     B *bb = getMemberTest2(&a);
-    EXPECT_TRUE((float)bb->x == (float)4.0);
-    EXPECT_TRUE((float)bb->y == (float)3.14);
+    EXPECT_EQ((float)bb->x, (float)4.0);
+    EXPECT_EQ((float)bb->y, (float)3.14);
     erpc_free(bb);
 }
 
@@ -68,7 +68,7 @@ TEST(test_struct, TestString1)
     char str[] = "Ape";
     prim8.species = &str[0];
     prim8.is_ape = false;
-    EXPECT_TRUE(checkString(&prim8) == 0);
+    EXPECT_EQ(checkString(&prim8), 0);
 }
 
 TEST(test_struct, TestReturnString1)
@@ -97,10 +97,10 @@ TEST(test_struct, TestStudent1)
     char *resultStudent = getStudentName(stud);
     EXPECT_STREQ("Donnie Darko", resultStudent);
     erpc_free(resultStudent);
-    EXPECT_TRUE(getStudentTestAverage(stud) == test_avg);
-    EXPECT_TRUE(getStudentAge(stud) == 19);
-    EXPECT_TRUE(SENIOR == 12);
-    EXPECT_TRUE(getStudentYear(stud) == SENIOR);
+    EXPECT_EQ(getStudentTestAverage(stud), test_avg);
+    EXPECT_EQ(getStudentAge(stud), 19);
+    EXPECT_EQ(SENIOR, 12);
+    EXPECT_EQ(getStudentYear(stud), SENIOR);
     erpc_free(stud);
 }
 
@@ -112,9 +112,9 @@ TEST(test_struct, TestStudent2)
     char *resultStudent = getStudentName(stud);
     EXPECT_STREQ("George Bush", resultStudent);
     erpc_free(resultStudent);
-    EXPECT_TRUE(getStudentTestAverage(stud) == 45.);
-    EXPECT_TRUE(getStudentAge(stud) == 68);
-    EXPECT_TRUE(getStudentYear(stud) == FRESHMAN);
+    EXPECT_EQ(getStudentTestAverage(stud), 45.);
+    EXPECT_EQ(getStudentAge(stud), 68);
+    EXPECT_EQ(getStudentYear(stud), FRESHMAN);
     erpc_free(stud->name);
     erpc_free(stud);
 }
@@ -209,23 +209,23 @@ TEST(test_struct, test_struct_allDirection)
 
     test_struct_allDirection(&a, &b, &e);
 
-    EXPECT_TRUE(e.number == a.number * b.number);
+    EXPECT_EQ(e.number, a.number * b.number);
 
     EXPECT_STREQ(text2, e.text);
     erpc_free(a.text);
     erpc_free(b.text);
     erpc_free(e.text);
 
-    EXPECT_TRUE(e.color == green);
+    EXPECT_EQ(e.color, green);
 
-    EXPECT_TRUE(e.c.m == a.c.m * b.c.m);
-    EXPECT_TRUE(e.c.n == a.c.n * b.c.n);
+    EXPECT_EQ(e.c.m, a.c.m * b.c.m);
+    EXPECT_EQ(e.c.n, a.c.n * b.c.n);
 
-    EXPECT_TRUE(e.list_numbers.elementsCount == 2);
+    EXPECT_EQ(e.list_numbers.elementsCount, 2);
 
     for (uint32_t i = 0; i < a.list_numbers.elementsCount; ++i)
     {
-        EXPECT_TRUE(e.list_numbers.elements[i] == a.list_numbers.elements[i] * b.list_numbers.elements[i]);
+        EXPECT_EQ(e.list_numbers.elements[i], a.list_numbers.elements[i] * b.list_numbers.elements[i]);
 
         EXPECT_STREQ(text2, e.list_text.elements[i]);
         erpc_free(a.list_text.elements[i]);
@@ -241,7 +241,7 @@ TEST(test_struct, test_struct_allDirection)
 
     for (uint32_t i = 0; i < 2; ++i)
     {
-        EXPECT_TRUE(e.array_numbers[i] == a.array_numbers[i] * b.array_numbers[i]);
+        EXPECT_EQ(e.array_numbers[i], a.array_numbers[i] * b.array_numbers[i]);
 
         EXPECT_STREQ(text2, e.array_text[i]);
         erpc_free(a.array_text[i]);
@@ -251,7 +251,7 @@ TEST(test_struct, test_struct_allDirection)
 
     for (uint8_t i = 0; i < a.binary_numbers.dataLength; ++i)
     {
-        EXPECT_TRUE(e.binary_numbers.data[i] == a.binary_numbers.data[i] * b.binary_numbers.data[i]);
+        EXPECT_EQ(e.binary_numbers.data[i], a.binary_numbers.data[i] * b.binary_numbers.data[i]);
     }
     erpc_free(a.binary_numbers.data);
     erpc_free(b.binary_numbers.data);

--- a/test/test_typedef/test_typedef_client_impl.cpp
+++ b/test/test_typedef/test_typedef_client_impl.cpp
@@ -19,14 +19,14 @@ TEST(test_typedef, SendReceiveInt)
 {
     int32type a = 10, b = 2 * a + 1, pB;
     pB = sendReceiveInt(a);
-    EXPECT_TRUE(b == pB);
+    EXPECT_EQ(b, pB);
 }
 
 TEST(test_typedef, SendReceiveEnum)
 {
     Colors a = green, pB, b = blue;
     pB = sendReceiveEnum(a);
-    EXPECT_TRUE((int32_t)b == (int32_t)pB);
+    EXPECT_EQ(b, pB);
 }
 
 TEST(test_typedef, SendReceiveStruct)
@@ -37,8 +37,8 @@ TEST(test_typedef, SendReceiveStruct)
     b->m = 2 * a->m;
     b->n = 2 + a->n;
     pB = sendReceiveStruct(a);
-    EXPECT_TRUE(b->m == pB->m);
-    EXPECT_TRUE(b->n == pB->n);
+    EXPECT_EQ(b->m, pB->m);
+    EXPECT_EQ(b->n, pB->n);
     erpc_free(a);
     erpc_free(b);
     erpc_free(pB);
@@ -62,7 +62,7 @@ TEST(test_typedef, SendReceiveListType)
     int32_t *list_p2 = received_list->elements;
     for (uint32_t i = 0; i < received_list->elementsCount; ++i)
     {
-        EXPECT_TRUE(*list_p2 / 2 == *list_p);
+        EXPECT_EQ(*list_p2 / 2, *list_p);
         ++list_p;
         ++list_p2;
     }
@@ -110,7 +110,7 @@ TEST(test_typedef, SendReceive2ListType)
         list_r = list_0_r->elements;
         for (uint32_t j = 0; j < list_0_r->elementsCount; ++j)
         {
-            EXPECT_TRUE((*list_r) / 2 == *list_s);
+            EXPECT_EQ((*list_r) / 2, *list_s);
             ++list_s;
             ++list_r;
         }

--- a/test/test_unions/test_unions_client_impl.cpp
+++ b/test/test_unions/test_unions_client_impl.cpp
@@ -24,7 +24,7 @@ TEST(test_unions, testGenericCallback)
         { gBleSuccess_c, gHciCommandStatus_c, 5 },
     };
     gapGenericEvent_t *newEvent = testGenericCallback(&event);
-    EXPECT_TRUE(newEvent->eventType == gWhiteListSizeReady_c);
+    EXPECT_EQ(newEvent->eventType, gWhiteListSizeReady_c);
     erpc_free(newEvent);
 
     event.eventType = gRandomAddressReady_c;
@@ -34,16 +34,16 @@ TEST(test_unions, testGenericCallback)
         event.eventData.aAddress[i] = x ^ 0xFF;
     }
     newEvent = testGenericCallback(&event);
-    EXPECT_TRUE(newEvent->eventType == gTestCaseReturn_c);
-    EXPECT_TRUE(newEvent->eventData.returnCode == 1);
+    EXPECT_EQ(newEvent->eventType, gTestCaseReturn_c);
+    EXPECT_EQ(newEvent->eventData.returnCode, 1);
     erpc_free(newEvent);
 
     event.eventType = gWhiteListSizeReady_c;
     event.eventData.whiteListSize = 100;
     newEvent = testGenericCallback(&event);
-    EXPECT_TRUE(newEvent->eventType == gTestCaseReturn_c);
+    EXPECT_EQ(newEvent->eventType, gTestCaseReturn_c);
     // printf("Vaue of return code: %d\n", newEvent->eventData.returnCode);
-    EXPECT_TRUE(newEvent->eventData.returnCode == 100);
+    EXPECT_EQ(newEvent->eventData.returnCode, 100);
     erpc_free(newEvent);
 }
 
@@ -58,8 +58,8 @@ TEST(test_unions, testUnionLists)
         myFoo.bing.a.elements[i] = i + 1;
     }
     foo *returnFoo = sendMyFoo(&myFoo);
-    EXPECT_TRUE(returnFoo->discriminator == returnVal);
-    EXPECT_TRUE(returnFoo->bing.ret == 0xAA);
+    EXPECT_EQ(returnFoo->discriminator, returnVal);
+    EXPECT_EQ(returnFoo->bing.ret, 0xAA);
     erpc_free((void *)myFoo.bing.a.elements);
     erpc_free((void *)returnFoo);
 
@@ -68,9 +68,9 @@ TEST(test_unions, testUnionLists)
     myFoo.bing.y = 4.0;
     returnFoo = sendMyFoo(&myFoo);
 
-    EXPECT_TRUE(returnFoo->discriminator == papaya);
-    EXPECT_TRUE(returnFoo->bing.x == 4);
-    EXPECT_TRUE(returnFoo->bing.y == 3);
+    EXPECT_EQ(returnFoo->discriminator, papaya);
+    EXPECT_EQ(returnFoo->bing.x, 4);
+    EXPECT_EQ(returnFoo->bing.y, 3);
 
     erpc_free((void *)returnFoo);
 }
@@ -89,8 +89,8 @@ TEST(test_unions, testNestedStructs)
     }
 
     foo *returnFoo = sendMyFoo(&myFoo);
-    EXPECT_TRUE(returnFoo->discriminator == returnVal);
-    EXPECT_TRUE(returnFoo->bing.ret == 0xAA);
+    EXPECT_EQ(returnFoo->discriminator, returnVal);
+    EXPECT_EQ(returnFoo->bing.ret, 0xAA);
     erpc_free((void *)myFoo.bing.myFoobar.rawString.data);
     erpc_free((void *)returnFoo);
 }
@@ -107,8 +107,8 @@ TEST(test_unions, testUnionAnn)
         myFoo.a.elements[i] = i + 1;
     }
     foo *returnFoo = sendMyUnion(discriminator, &myFoo);
-    EXPECT_TRUE(returnFoo->discriminator == returnVal);
-    EXPECT_TRUE(returnFoo->bing.ret == 0xAA);
+    EXPECT_EQ(returnFoo->discriminator, returnVal);
+    EXPECT_EQ(returnFoo->bing.ret, 0xAA);
     erpc_free((void *)myFoo.a.elements);
     erpc_free((void *)returnFoo);
 
@@ -117,9 +117,9 @@ TEST(test_unions, testUnionAnn)
     myFoo.y = 4.0;
     returnFoo = sendMyUnion(discriminator, &myFoo);
 
-    EXPECT_TRUE(returnFoo->discriminator == papaya);
-    EXPECT_TRUE(returnFoo->bing.x == 4);
-    EXPECT_TRUE(returnFoo->bing.y == 3);
+    EXPECT_EQ(returnFoo->discriminator, papaya);
+    EXPECT_EQ(returnFoo->bing.x, 4);
+    EXPECT_EQ(returnFoo->bing.y, 3);
 
     erpc_free((void *)returnFoo);
 }


### PR DESCRIPTION
EXPECT_EQ provide more information in most of cases on fail.

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [ ] bug
- [X] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
In case of error EXPECT_EQ is returning detailed information.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.
- X] Allow edits from maintainers pull request option is set (recommended).

**Additional context**
<!--
Add any other context about the problem here.
-->
