### PR TITLE
Change default build target to release + adding artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
       - checkout
       - run: chmod u+x install_dependencies.sh && ./install_dependencies.sh
       - run: chmod u+x run_tests.sh && ./run_tests.sh
+      - store_artifacts:
+          path: ./Release/Linux/erpcgen/erpcgen
   build-linux-clang:
     machine:
       image: ubuntu-2204:2022.04.2 #https://circleci.com/developer/machine/image/ubuntu-2204 pick LTS
@@ -15,6 +17,8 @@ jobs:
       - checkout
       - run: chmod u+x install_dependencies.sh && ./install_dependencies.sh clang
       - run: chmod u+x run_tests.sh && ./run_tests.sh clang
+      - store_artifacts:
+          path: ./Release/Linux/erpcgen/erpcgen
   build-mac-gcc:
     macos:
       xcode: 13.2.1
@@ -38,3 +42,5 @@ workflows:
       - build-linux-clang
       # - build-mac-gcc # Mac is on going, or it can be hosted on company computer.
       # - build-mac-clang
+
+# VS Code Extension Version: 1.5.1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/EmbeddedRPC/erpc/pulls)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/EmbeddedRPC/erpc)
 
+- [eRPC](#erpc)
+  - [About](#about)
+  - [Releases](#releases)
+    - [Edge releases](#edge-releases)
+  - [Documentation](#documentation)
+  - [Examples](#examples)
+  - [References](#references)
+  - [Directories](#directories)
+  - [Building and installing](#building-and-installing)
+    - [Requirements](#requirements)
+      - [Windows](#windows)
+      - [Linux and Cygwin](#linux-and-cygwin)
+      - [Mac OS X](#mac-os-x)
+    - [Building](#building)
+    - [Installing for Python](#installing-for-python)
+  - [Known issues and limitations](#known-issues-and-limitations)
+  - [Code providing](#code-providing)
+
+## About
+
 eRPC (Embedded RPC) is an open source Remote Procedure Call (RPC) system for multichip embedded systems and heterogeneous multicore SoCs.
 
 Unlike other modern RPC systems, such as the excellent [Apache Thrift](http://thrift.apache.org), eRPC distinguishes itself by being designed for tightly coupled systems, using plain C for remote functions, and having a small code size (<5kB). It is not intended for high performance distributed systems over a network.
@@ -82,7 +102,7 @@ eRPC is available with an unrestrictive BSD 3-clause license. See the [LICENSE f
 
 [eRPC releases](https://github.com/EmbeddedRPC/erpc/releases)
 
-### edge releases
+### Edge releases
 
 Edge releases can by found on [eRPC CircleCI](https://app.circleci.com/pipelines/github/EmbeddedRPC/erpc) webpage. Choose build of interest, then platform target and choose ARTIFACTS tab. Here you can find binary application from chosen build.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ eRPC is available with an unrestrictive BSD 3-clause license. See the [LICENSE f
 
 [eRPC releases](https://github.com/EmbeddedRPC/erpc/releases)
 
+### edge releases
+
+Edge releases can by found on [eRPC CircleCI](https://app.circleci.com/pipelines/github/EmbeddedRPC/erpc) webpage. Choose build of interest, then platform target and choose ARTIFACTS tab. Here you can find binary application from chosen build.
+
 ## Documentation
 
 [Documentation](https://github.com/EmbeddedRPC/erpc/wiki) is in the `wiki` section.

--- a/erpcgen/Makefile
+++ b/erpcgen/Makefile
@@ -117,10 +117,10 @@ include $(ERPC_ROOT)/mk/targets.mk
 
 ifeq "$(is_mingw)" "1"
     LIBRARIES += -L$(BOOST_ROOT)/stage/lib
-    ifeq "$(build)" "debug"
-        LIBRARIES += -lboost_system-mgw48-mt-1_57 -lboost_filesystem-mgw48-mt-1_57
-    else
+    ifeq "$(build)" "release"
         LIBRARIES += -lboost_system-mgw48-mt-d-1_57 -lboost_filesystem-mgw48-mt-d-1_57
+    else
+        LIBRARIES += -lboost_system-mgw48-mt-1_57 -lboost_filesystem-mgw48-mt-1_57
     endif
 else
     ifeq "$(is_linux)" "1"
@@ -128,7 +128,7 @@ else
     endif
 
     static_libs := NO
-    ifneq "$(build)" "debug"
+    ifeq "$(build)" "release"
         ifeq "$(is_darwin)" "1"
             static_libs := $(BOOST_ROOT)/lib/libboost_system.a $(BOOST_ROOT)/lib/libboost_filesystem.a
         endif
@@ -141,7 +141,7 @@ else
 endif
 
 # Release should be alwas static. Customers don't need install things.
-ifneq "$(build)" "debug"
+ifeq "$(build)" "release"
     # Except Darwin. Darwin has static libs defined above.
     ifeq "$(is_darwin)" ""
         LIBRARIES += -static

--- a/erpcgen/test/config.py
+++ b/erpcgen/test/config.py
@@ -27,9 +27,9 @@ this_dir = path.local(__file__).dirpath()
 if 'ERPCGEN' in os.environ:
     ERPCGEN = os.environ['ERPCGEN']
 elif sys.platform == 'win32':
-    ERPCGEN = str(this_dir.join(r"..\VisualStudio_v14\Debug\erpcgen.exe"))
+    ERPCGEN = str(this_dir.join(r"..\VisualStudio_v14\Release\erpcgen.exe"))
 else:
-    ERPCGEN = str(this_dir.join("../../Debug/{}/erpcgen/erpcgen".format(os_name)))
+    ERPCGEN = str(this_dir.join("../../Release/{}/erpcgen/erpcgen".format(os_name)))
 
 # Set path to C/C++ compiler.
 if 'CC' in os.environ:
@@ -39,4 +39,3 @@ else:
 
 # Number of test runs to keep.
 RUN_KEEP_COUNT = 3
-

--- a/erpcsniffer/Makefile
+++ b/erpcsniffer/Makefile
@@ -79,10 +79,10 @@ include $(ERPC_ROOT)/mk/targets.mk
 
 ifeq "$(is_mingw)" "1"
     LIBRARIES += -L$(BOOST_ROOT)/stage/lib
-    ifeq "$(build)" "debug"
-        LIBRARIES += -lboost_system-mgw48-mt-1_57 -lboost_filesystem-mgw48-mt-1_57
-    else
+    ifeq "$(build)" "release"
         LIBRARIES += -lboost_system-mgw48-mt-d-1_57 -lboost_filesystem-mgw48-mt-d-1_57
+    else
+        LIBRARIES += -lboost_system-mgw48-mt-1_57 -lboost_filesystem-mgw48-mt-1_57
     endif
 else
     ifeq "$(is_linux)" "1"
@@ -90,7 +90,7 @@ else
     endif
 
     static_libs := NO
-    ifneq "$(build)" "debug"
+    ifeq "$(build)" "release"
         ifeq "$(is_darwin)" "1"
             static_libs := $(BOOST_ROOT)/lib/libboost_system.a $(BOOST_ROOT)/lib/libboost_filesystem.a
         endif
@@ -103,7 +103,7 @@ else
 endif
 
 # Release should be alwas static. Customers don't need install things.
-ifneq "$(build)" "debug"
+ifeq "$(build)" "release"
     # Except Darwin. Darwin has static libs defined above.
     ifeq "$(is_darwin)" ""
 #        LIBRARIES += -static

--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -60,15 +60,14 @@ else
     ARFLAGS = -rcs
 endif
 
-ifeq "$(build)" "debug"
-    DEBUG_OR_RELEASE := Debug
-    CFLAGS += -g3 -O0 -DDEBUG -DYYDEBUG=1
-    CXXFLAGS += -g3 -O0 -DDEBUG -DYYDEBUG=1
-    LDFLAGS +=
-else
+ifeq "$(build)" "release"
     DEBUG_OR_RELEASE := Release
     CFLAGS += -Os -DNDEBUG
     CXXFLAGS += -Os -DNDEBUG
+else
+    DEBUG_OR_RELEASE := Debug
+    CFLAGS += -g3 -O0 -DDEBUG -DYYDEBUG=1
+    CXXFLAGS += -g3 -O0 -DDEBUG -DYYDEBUG=1
 endif
 
 ifneq "$(is_mingw)" "1"

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -105,4 +105,4 @@ endif
 # Debug or Release
 # Release by default
 #-----------------------------------------------
-build ?= debug
+build ?= release

--- a/test/run_unit_tests.py
+++ b/test/run_unit_tests.py
@@ -35,7 +35,7 @@ def isTestDir(dir):
 testClientCommand = "run-tcp-client"
 testServerCommand = "run-tcp-server"
 transportLayer = "tcp"
-target = "debug"
+target = "release"
 
 # Process command line options
 # Check for 2 or more arguments because argv[0] is the script name


### PR DESCRIPTION
Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [X] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
It doesn't make sense to have default target debug as it is for debugging builds, but as default we wan't debug them but only build and use. If they are failing then we wan't build debug target and debug issue.

Our comments is saying same:
![image](https://user-images.githubusercontent.com/13130700/211040613-12f6f95c-40a5-4882-9c35-3092b4eee2b8.png)


+++ Ading artefacts so we will have available binaries for every build. Users may benefit to get nightly-version of eRPC app.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->
previously we need modify build var for getting release target. Now we need to modify it for debug.

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->
Build release target by default

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [X] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).

**Additional context**
<!--
Add any other context about the problem here.
-->
