### PR TITLE
Fix typo in assert

### DIFF
--- a/erpc_c/setup/erpc_server_setup.cpp
+++ b/erpc_c/setup/erpc_server_setup.cpp
@@ -200,7 +200,7 @@ void erpc_client_add_pre_cb_action(erpc_server_t server, pre_post_action_cb preC
 
 void erpc_client_add_post_cb_action(erpc_server_t server, pre_post_action_cb postCB)
 {
-    erpc_assert(server) != NULL;
+    erpc_assert(server != NULL);
 
     SimpleServer *simpleServer = reinterpret_cast<SimpleServer *>(server);
 


### PR DESCRIPTION
# Pull request

**Choose Correct**

- [X] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
There is typo where the null is checked against the assert instead of in the assert
**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [ ] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [ ] PR code is tested.
- [X] PR code is formatted.
- [X] Allow edits from maintainers pull request option is set (recommended).

**Additional context**
<!--
Add any other context about the problem here.
-->
