### PR TITLE
Fix spi and i2c header offset

### DIFF
--- a/erpc_python/erpc/transport.py
+++ b/erpc_python/erpc/transport.py
@@ -301,6 +301,7 @@ class LIBUSBSIOSPITransport(FramedTransport):
         self._hSIOPort = None
 
     def _base_send(self, message):
+        #TODO: can we send data at once ?
         # Wait for SPI master-slave signalling GPIO pin to be in low state
         res = self.sio.GPIO_GetPin(self._gpioport, self._gpiopin)
         while (1 == res):
@@ -312,7 +313,7 @@ class LIBUSBSIOSPITransport(FramedTransport):
             #print('SPI received %d number of bytes' % rxbytesnumber)
             # Send the payload/data
             data, rxbytesnumber = self._hSPIPort.Transfer(
-                0, 15, bytes(message[4:]), len(message) - self.HEADER_LEN, 0)
+                0, 15, bytes(message[self.HEADER_LEN:]), len(message) - self.HEADER_LEN, 0)
         else:
             print('SPI transfer error: %d' % rxbytesnumber)
 
@@ -407,6 +408,7 @@ class LIBUSBSIOI2CTransport(FramedTransport):
         self._hSIOPort = None
 
     def _base_send(self, message):
+        #TODO: can we send data at once ?
         # Wait for I2C master-slave signalling GPIO pin to be in low state
         res = self.sio.GPIO_GetPin(self._gpioport, self._gpiopin)
         while (1 == res):
@@ -418,7 +420,7 @@ class LIBUSBSIOI2CTransport(FramedTransport):
             #print('I2C received %d number of bytes' % rxbytesnumber)
             # Send the payload/data
             data, rxbytesnumber = self._hI2CPort.FastXfer(
-                0x7E, bytes(message[4:]), len(message) - self.HEADER_LEN, 0, False, True)
+                0x7E, bytes(message[self.HEADER_LEN:]), len(message) - self.HEADER_LEN, 0, False, True)
         else:
             print('I2C transfer error: %d' % rxbytesnumber)
 


### PR DESCRIPTION
align with new implementation

# Pull request

**Choose Correct**

- [X] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->
Fixing spi and i2c header offset when sending data in python.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [x] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [ ] PR code is tested.
- [ ] PR code is formatted.
- [X] Allow edits from maintainers pull request option is set (recommended).

**Additional context**
<!--
Add any other context about the problem here.
-->
