### PR TITLE
Remove cstbool library

### DIFF
--- a/erpc_c/transports/erpc_spi_master_transport.hpp
+++ b/erpc_c/transports/erpc_spi_master_transport.hpp
@@ -12,7 +12,6 @@
 
 #include "erpc_framed_transport.hpp"
 
-#include <cstdbool>
 #include <cstdlib>
 
 extern "C" {

--- a/erpcgen/src/HexValues.hpp
+++ b/erpcgen/src/HexValues.hpp
@@ -9,7 +9,6 @@
 #if !defined(_HexValues_h_)
 #define _HexValues_h_
 
-#include <cstdbool>
 #include <cstdint>
 
 //! \brief Determines whether \a c is a hex digit character.

--- a/erpcgen/src/templates/c_common_header.template
+++ b/erpcgen/src/templates/c_common_header.template
@@ -26,7 +26,6 @@ extern "C"
 #include <stddef.h>
 #include <stdint.h>
 {% else %}
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 {% endif %}

--- a/examples/zephyr/matrix_multiply_rpmsglite/remote/src/service/erpc_matrix_multiply_common.hpp
+++ b/examples/zephyr/matrix_multiply_rpmsglite/remote/src/service/erpc_matrix_multiply_common.hpp
@@ -17,7 +17,6 @@
 #define _erpc_matrix_multiply_common_hpp_
 
 
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 

--- a/examples/zephyr/matrix_multiply_rpmsglite/src/service/erpc_matrix_multiply_common.hpp
+++ b/examples/zephyr/matrix_multiply_rpmsglite/src/service/erpc_matrix_multiply_common.hpp
@@ -17,7 +17,6 @@
 #define _erpc_matrix_multiply_common_hpp_
 
 
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 

--- a/examples/zephyr/matrix_multiply_uart/src/service/erpc_matrix_multiply_common.hpp
+++ b/examples/zephyr/matrix_multiply_uart/src/service/erpc_matrix_multiply_common.hpp
@@ -17,7 +17,6 @@
 #define _erpc_matrix_multiply_common_hpp_
 
 
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/header/cstdbool

# Pull request

**Choose Correct**

- [X] bug
- [ ] feature

**Describe the pull request**
Based on https://en.cppreference.com/w/cpp/header/cstdbool the library is deprecated and removed.

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
Nothing changed

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [X] PR code is formatted.
- [ ] Allow edits from maintainers pull request option is set (recommended).

**Additional context**
<!--
Add any other context about the problem here.
-->
