### PR TITLE
Call assert for listType before dereferencing

### DIFF
--- a/erpcgen/src/CGenerator.cpp
+++ b/erpcgen/src/CGenerator.cpp
@@ -305,8 +305,8 @@ DataType *CGenerator::findChildDataType(set<DataType *> &dataTypes, DataType *da
         {
             // The only child node of a list node is the element type.
             ListType *listType = dynamic_cast<ListType *>(dataType);
-            DataType *trueContainerDataType = listType->getTrueContainerDataType();
             assert(listType);
+            DataType *trueContainerDataType = listType->getTrueContainerDataType();
             DataType *elementType = findChildDataType(dataTypes, listType->getElementType());
             listType->setElementType(elementType);
 


### PR DESCRIPTION
# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
<!--
`assert(listType)` is now called before dereferencing of `listType`
-->

## To Reproduce
<!--
No
-->

## Expected behavior
<!--
If the `dynamic_cast` accidentally returns NULL, it should be caught by `assert()` before dereferencing.
-->

## Desktop (please complete the following information):

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).
