### PR TITLE
Fix linking error on FreeRTOS when using portYIELD_FROM_ISR

### DIFF
--- a/erpc_c/port/erpc_threading_freertos.cpp
+++ b/erpc_c/port/erpc_threading_freertos.cpp
@@ -14,6 +14,15 @@
 
 #if ERPC_THREADS_IS(FREERTOS)
 
+// The portYIELD_FROM_ISR() macro declares a variable called
+// ulPortYieldRequired. FreeRTOS assumes ulPortYieldRequired is in the
+// global namespace. To prevent linking errors, portYIELD_FROM_ISR()
+// should not be called from within a namespace.
+inline void ErpcPortYieldFromISR(BaseType_t &higher_priority_task_woken)
+{
+    portYIELD_FROM_ISR(higher_priority_task_woken);
+}
+
 using namespace erpc;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -248,7 +257,7 @@ void Semaphore::putFromISR(void)
 {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     (void)xSemaphoreGiveFromISR(m_sem, &xHigherPriorityTaskWoken);
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    ErpcPortYieldFromISR(xHigherPriorityTaskWoken);
 }
 
 bool Semaphore::get(uint32_t timeoutUsecs)


### PR DESCRIPTION
# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
The `portYIELD_FROM_ISR()` macro declares a variable called `ulPortYieldRequired`. 
FreeRTOS assumes `ulPortYieldRequired` is in the global namespace.
To prevent linking errors, this PR introduces a function in the global namespace called `ErpcPortYieldFromISR` that then calls `portYIELD_FROM_ISR()`.

## To Reproduce
Build eRPC with FreeRTOS.

## Expected behavior
eRPC builds as normal.

## Desktop (please complete the following information):

- OS<!--[e.g. iOS]-->: Ubuntu 20.04
- eRPC Version<!--[e.g. v1.9.0]-->: v1.12.0 and earlier

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).
