### PR TITLE
client manager: added user context to error handler (#424)

### DIFF
--- a/erpc_c/infra/erpc_client_manager.cpp
+++ b/erpc_c/infra/erpc_client_manager.cpp
@@ -219,6 +219,6 @@ void ClientManager::callErrorHandler(erpc_status_t err, uint32_t functionID)
 {
     if (m_errorHandler != NULL)
     {
-        m_errorHandler(err, functionID);
+        m_errorHandler(err, functionID, m_errorHandlerContext);
     }
 }

--- a/erpc_c/infra/erpc_client_manager.h
+++ b/erpc_c/infra/erpc_client_manager.h
@@ -29,8 +29,9 @@ extern "C" {
 #include "erpc_common.h"
 #endif
 
-typedef void (*client_error_handler_t)(erpc_status_t err,
-                                       uint32_t functionID); /*!< eRPC error handler function type. */
+typedef void (*client_error_handler_t)(erpc_status_t err,   /*!< eRPC error code. */
+                                       uint32_t functionID, /*!< eRPC error handler function type. */
+                                       void *context);      /*!< User supplied context. */
 
 //! @brief Opaque client object type.
 typedef struct ClientType *erpc_client_t;
@@ -62,7 +63,7 @@ public:
      * This function initializes object attributes.
      */
     ClientManager(void) :
-    ClientServerCommon(), m_sequence(0), m_errorHandler(NULL)
+    ClientServerCommon(), m_sequence(0), m_errorHandler(NULL), m_errorHandlerContext(NULL)
 #if ERPC_NESTED_CALLS
     ,
     m_server(NULL), m_serverThreadId(NULL)
@@ -100,8 +101,13 @@ public:
      * @brief This function sets error handler function for infrastructure errors.
      *
      * @param[in] error_handler Pointer to error handler function.
+     * @param[in] error_handler_context Pointer to error handler user context.
      */
-    void setErrorHandler(client_error_handler_t error_handler) { m_errorHandler = error_handler; }
+    void setErrorHandler(client_error_handler_t error_handler, void *error_handler_context)
+    {
+        m_errorHandler = error_handler;
+        m_errorHandlerContext = error_handler_context;
+    }
 
     /*!
      * @brief This function calls error handler callback function with given status.
@@ -132,6 +138,7 @@ public:
 protected:
     uint32_t m_sequence;                   //!< Sequence number.
     client_error_handler_t m_errorHandler; //!< Pointer to function error handler.
+    void *m_errorHandlerContext;           //!< Pointer to a user supplied context.
 #if ERPC_NESTED_CALLS
     Server *m_server;                     //!< Server used for nested calls.
     Thread::thread_id_t m_serverThreadId; //!< Thread in which server run function is called.

--- a/erpc_c/setup/erpc_arbitrated_client_setup.cpp
+++ b/erpc_c/setup/erpc_arbitrated_client_setup.cpp
@@ -34,7 +34,7 @@ ERPC_MANUALLY_CONSTRUCTED_STATIC(ArbitratedClientManager, s_client);
 #if defined(__MINGW32__)
 __declspec(selectany)
 #endif
-    ClientManager *g_client;
+ClientManager *g_client;
 #if !defined(__MINGW32__)
 #pragma weak g_client
 #endif
@@ -162,7 +162,7 @@ void erpc_arbitrated_client_set_error_handler(erpc_client_t client, client_error
 
     ArbitratedClientManager *clientManager = reinterpret_cast<ArbitratedClientManager *>(client);
 
-    clientManager->setErrorHandler(error_handler);
+    clientManager->setErrorHandler(error_handler, NULL);
 }
 
 void erpc_arbitrated_client_set_crc(erpc_client_t client, uint32_t crcStart)

--- a/erpc_c/setup/erpc_client_setup.cpp
+++ b/erpc_c/setup/erpc_client_setup.cpp
@@ -32,7 +32,7 @@ ERPC_MANUALLY_CONSTRUCTED_STATIC(ClientManager, s_client);
 #if defined(__MINGW32__)
 __declspec(selectany)
 #endif
-    ClientManager *g_client;
+ClientManager *g_client;
 #if !defined(__MINGW32__)
 #pragma weak g_client
 #endif
@@ -121,7 +121,7 @@ void erpc_client_set_error_handler(erpc_client_t client, client_error_handler_t 
 
     ClientManager *clientManager = reinterpret_cast<ClientManager *>(client);
 
-    clientManager->setErrorHandler(error_handler);
+    clientManager->setErrorHandler(error_handler, NULL);
 }
 
 void erpc_client_set_crc(erpc_client_t client, uint32_t crcStart)


### PR DESCRIPTION
# Pull request

## Choose Correct

- [ ] bug
- [x] feature

## Describe the pull request
<!--
A clear and concise description of what the pull request is.
-->

This pull request addresses and propose a possible implementation regarding the feature request presented in #424 

## To Reproduce
<!--
Steps to reproduce the behavior.
-->

When registering an error handler, the user can supply its own context (or `nullptr`).

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context
<!--
Add any other context about the problem here.
-->
