### PR TITLE
Make java code jdk11 compliant

### DIFF
--- a/erpc_java/deploy.xml
+++ b/erpc_java/deploy.xml
@@ -38,8 +38,8 @@
 
     <properties>
         <!-- Java version configuration -->
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Plugins versions -->

--- a/erpc_java/pom.xml
+++ b/erpc_java/pom.xml
@@ -38,8 +38,8 @@
 
     <properties>
         <!-- Java version configuration -->
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Plugins versions -->

--- a/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/MessageInfo.java
+++ b/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/MessageInfo.java
@@ -6,17 +6,80 @@
 
 package  io.github.embeddedrpc.erpc.auxiliary;
 
+import java.util.Objects;
+
+public final class MessageInfo {
+        private final MessageType type;
+        private final int service;
+        private final int request;
+        private final int sequence;
+
 /**
- * Record storing information about message.
+ * Class storing information about message.
  *
  * @param type     Message type
  * @param service  Service identification
  * @param request  Request identification
  * @param sequence Sequence number
  */
-public record MessageInfo(
-        MessageType type,
-        int service,
-        int request,
-        int sequence) {
+  public MessageInfo(MessageType type, int service, int request, int sequence) {
+     this.type = type;
+     this.service = service;
+     this.request = request;
+     this.sequence = sequence;
+  }
+
+/**
+ * Get message type.
+ *
+ * @return type
+*/
+  public MessageType type() {
+      return type;
+  }
+
+/**
+ * Get message service.
+ *
+ * @return service
+*/
+    public int service() {
+        return service;
+    }
+
+/**
+ * Get message request.
+ *
+ * @return request
+*/
+    public int request() {
+        return request;
+    }
+
+
+/**
+ * Get message sequence.
+ *
+ * @return sequence
+*/
+    public int sequence() {
+        return sequence;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MessageInfo)) {
+            return false;
+        }
+        MessageInfo that = (MessageInfo) o;
+        return service == that.service && request == that.request && sequence == that.sequence && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, service, request, sequence);
+    }
 }

--- a/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/MessageType.java
+++ b/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/MessageType.java
@@ -57,12 +57,17 @@ public enum MessageType {
      * @return Corresponding MessageType
      */
     public static MessageType getMessageType(int value) {
-        return switch (value) {
-            case 0 -> kInvocationMessage;
-            case 1 -> kOnewayMessage;
-            case 2 -> kReplyMessage;
-            case 3 -> kNotificationMessage;
-            default -> throw new RuntimeException("Invalid MessageType " + value);
-        };
+        switch (value) {
+            case 0:
+              return kInvocationMessage;
+            case 1:
+              return kOnewayMessage;
+            case 2:
+              return kReplyMessage;
+            case 3:
+              return kNotificationMessage;
+            default:
+              throw new RuntimeException("Invalid MessageType " + value);
+        }
     }
 }

--- a/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/RequestContext.java
+++ b/erpc_java/src/main/java/io/github/embeddedrpc/erpc/auxiliary/RequestContext.java
@@ -9,13 +9,82 @@ package  io.github.embeddedrpc.erpc.auxiliary;
 import  io.github.embeddedrpc.erpc.codec.Codec;
 import groovyjarjarantlr.ByteBuffer;
 
+import java.util.Objects;
+
+public final class RequestContext {
+  private final int sequence;
+  private final ByteBuffer message;
+  private final Codec codec;
+  private final Boolean isOneWay;
+
 /**
- * Record storing request context.
+ * Class storing request context.
  *
  * @param sequence Sequence number
  * @param message  Message to be sent
  * @param codec    Codec used to store send and received message
  * @param isOneWay Request direction
  */
-public record RequestContext(int sequence, ByteBuffer message, Codec codec, Boolean isOneWay) {
+  public RequestContext(int sequence, ByteBuffer message, Codec codec, Boolean isOneWay) {
+      this.sequence = sequence;
+      this.message = message;
+      this.codec = codec;
+      this.isOneWay = isOneWay;
+  }
+
+/**
+ * Get request context sequence.
+ *
+ * @return sequence
+*/
+    public int sequence() {
+        return sequence;
+    }
+
+/**
+ * Get request context message.
+ *
+ * @return message
+*/
+    public ByteBuffer message() {
+        return message;
+    }
+
+/**
+ * Get request context codec.
+ *
+ * @return codec
+*/
+    public Codec codec() {
+        return codec;
+    }
+
+/**
+ * is request context oneWay.
+ *
+ * @return isOneWay
+*/
+    public boolean isOneWay() {
+        return isOneWay;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RequestContext)) {
+            return false;
+        }
+        RequestContext that = (RequestContext) o;
+        return sequence == that.sequence
+                && Objects.equals(message, that.message)
+                && Objects.equals(codec, that.codec)
+                && Objects.equals(isOneWay, that.isOneWay);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sequence, message, codec, isOneWay);
+    }
 }


### PR DESCRIPTION
# Pull request

## Choose Correct

- [ ] bug
- [x] feature

## Describe the pull request
The eRPC infrastructure code for java imposed a requirement of JDK21, this pull request aims to remove the usages of newer java features in order to make it compliant with language level 11.


## Expected behavior
The eRPC project can now be used in java projects that target at least java 11.


## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).
