### PR TITLE
Fix nestingDetection undefined (cpp_server_source.template)

### DIFF
--- a/erpcgen/src/templates/cpp_server_source.template
+++ b/erpcgen/src/templates/cpp_server_source.template
@@ -20,6 +20,7 @@ using namespace std;
 
 #if ERPC_NESTED_CALLS_DETECTION
 extern bool nestingDetection;
+bool nestingDetection = false;
 #endif
 
 {$generateCrcVariable()}


### PR DESCRIPTION
# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
fix nestingDetection undefined

## To Reproduce
<!--
Steps to reproduce the behavior.
-->

## Expected behavior
```
extern bool nestingDetection;
bool nestingDetection = false;
```

## Screenshots
![image](https://github.com/user-attachments/assets/89c2693c-53ea-49f2-babb-f6b574527b80)

## Desktop (please complete the following information):

- OS<!--[e.g. iOS]-->: Ubuntu
- eRPC Version<!--[e.g. v1.9.0]-->: 1.13.0

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context
<!--
Add any other context about the problem here.
-->
