### PR TITLE
Free the arbitrated client token from client manager

### DIFF
--- a/erpc_c/infra/erpc_arbitrated_client_manager.cpp
+++ b/erpc_c/infra/erpc_arbitrated_client_manager.cpp
@@ -87,6 +87,12 @@ void ArbitratedClientManager::performClientRequest(RequestContext &request)
             request.getCodec()->updateStatus(err);
         }
 
+        if (token != 0)
+        {
+            // Also if status bad, need to free the token.
+            m_arbitrator->removePendingClient(token);
+        }
+
 #if ERPC_MESSAGE_LOGGING
         if (request.getCodec()->isStatusOk() == true)
         {

--- a/erpc_c/infra/erpc_transport_arbitrator.cpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.cpp
@@ -193,8 +193,6 @@ erpc_status_t TransportArbitrator::clientReceive(client_token_t token)
     // Wait on the semaphore until we're signaled.
     info->m_sem.get(Semaphore::kWaitForever);
 
-    removePendingClient(info);
-
     return kErpcStatus_Success;
 }
 
@@ -227,10 +225,15 @@ TransportArbitrator::PendingClientInfo *TransportArbitrator::addPendingClient(vo
     return info;
 }
 
-void TransportArbitrator::removePendingClient(PendingClientInfo *info)
+void TransportArbitrator::removePendingClient(client_token_t token)
 {
+    // Convert token to pointer to info struct.
+    PendingClientInfo *info = reinterpret_cast<PendingClientInfo *>(token);
     Mutex::Guard lock(m_clientListMutex);
     PendingClientInfo *node;
+
+    erpc_assert((token != 0) && ("invalid client token" != NULL));
+    erpc_assert((info->m_sem.getCount() == 0) && ("Semaphore should be clean" != NULL));
 
     // Clear fields.
     info->m_request = NULL;

--- a/erpc_c/infra/erpc_transport_arbitrator.hpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.hpp
@@ -158,6 +158,13 @@ public:
     erpc_status_t clientReceive(client_token_t token);
 
     /*!
+     * @brief This function free client token.
+     *
+     * @param[in] token the client token to remove.
+     */
+    void removePendingClient(client_token_t token);
+
+    /*!
      * @brief Request info for a client trying to receive a response.
      */
     struct PendingClientInfo
@@ -199,13 +206,6 @@ protected:
      * @return Pending client information.
      */
     PendingClientInfo *addPendingClient(void);
-
-    /*!
-     * @brief This function removes pending client.
-     *
-     * @param[in] info Pending client info to remove.
-     */
-    void removePendingClient(PendingClientInfo *info);
 
     /*!
      * @brief This function removes pending client list.


### PR DESCRIPTION
# Pull request

## Choose Correct

- [X] bug
- [ ] feature

## Describe the pull request
<!--
A clear and concise description of what the pull request is.
-->
Closes #443 , Make the token free be from the client management and it will be not matter what is the status
## To Reproduce
<!--
Steps to reproduce the behavior.
-->

## Expected behavior
<!--
A clear and concise description of what you expected to happen.
-->

## Screenshots
<!--
If applicable, add screenshots to help explain your problem.
-->

## Desktop (please complete the following information):

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

## Steps you didn't forgot to do

- [X] I checked if other PR isn't solving this issue.
- [X] I read Contribution details and did appropriate actions.
- [X] PR code is tested.
- [X] PR code is formatted.
- [X] Allow edits from maintainers pull request option is set (recommended).

## Additional context
<!--
Add any other context about the problem here.
-->
