### PR TITLE
Fix missing header after make install

### DIFF
--- a/erpc_c/Makefile
+++ b/erpc_c/Makefile
@@ -91,6 +91,7 @@ HEADERS += 	$(ERPC_C_ROOT)/config/erpc_config.h \
 			$(ERPC_C_ROOT)/infra/erpc_message_buffer.hpp \
 			$(ERPC_C_ROOT)/infra/erpc_message_loggers.hpp \
 			$(ERPC_C_ROOT)/infra/erpc_server.hpp \
+			$(ERPC_C_ROOT)/infra/erpc_simple_server.hpp \
 			$(ERPC_C_ROOT)/infra/erpc_static_queue.hpp \
 			$(ERPC_C_ROOT)/infra/erpc_transport_arbitrator.hpp \
 			$(ERPC_C_ROOT)/infra/erpc_transport.hpp \


### PR DESCRIPTION
# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
This PR fixes the `erpc_c` `Makefile`, the `erpc_simple_server.hpp` header was never installed.

## To Reproduce
Compile the library with `make`, than try to install it with `make install`, the `erpc_simple_server.hpp` file won't be copied to the include directory.

## Expected behavior
`erpc_simple_server.hpp` should be installed and available to consumers.

## Desktop (please complete the following information):

- OS<!--[e.g. iOS]-->: Linux Ubuntu 24.04 x86_64, Linux Yocto (multiple architectures)
- eRPC Version<!--[e.g. v1.9.0]-->: v1.13.0

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).
