### PR TITLE
Fix the naming error of erpc_server_add_pre_cb_action and erpc_server_add_post_cb_action

### DIFF
--- a/erpc_c/setup/erpc_server_setup.cpp
+++ b/erpc_c/setup/erpc_server_setup.cpp
@@ -189,7 +189,7 @@ bool erpc_server_add_message_logger(erpc_server_t server, erpc_transport_t trans
 #endif
 
 #if ERPC_PRE_POST_ACTION
-void erpc_client_add_pre_cb_action(erpc_server_t server, pre_post_action_cb preCB)
+void erpc_server_add_pre_cb_action(erpc_server_t server, pre_post_action_cb preCB)
 {
     erpc_assert(server != NULL);
 
@@ -198,7 +198,7 @@ void erpc_client_add_pre_cb_action(erpc_server_t server, pre_post_action_cb preC
     simpleServer->addPreCB(preCB);
 }
 
-void erpc_client_add_post_cb_action(erpc_server_t server, pre_post_action_cb postCB)
+void erpc_server_add_post_cb_action(erpc_server_t server, pre_post_action_cb postCB)
 {
     erpc_assert(server != NULL);
 


### PR DESCRIPTION
Fix the naming error of erpc_server_add_pre_cb_action and erpc_server_add_post_cb_action

# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
Fix the naming error of erpc_server_add_pre_cb_action and erpc_server_add_post_cb_action

## To Reproduce
When I call the erpc_server_add_pre_cb_action function, it can not compile.

## Expected behavior
erpc_server_add_pre_cb_action can be called successfully.

## Screenshots

## Desktop (please complete the following information):

- OS: all platfrom
- eRPC Version: newest version in main branch

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context

