### PR TITLE
Applying fix suggested in bug #461

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -13,7 +13,6 @@ config ERPC
 	help
 	  This option enables the eRPC library
 	depends on CPP
-	depends on FULL_LIBCPP_SUPPORTED
 
 config ZEPHYR_BUILD
 	bool


### PR DESCRIPTION
# Pull request

## Choose Correct

- [x] bug
- [ ] feature

## Describe the pull request
Applying fix suggested in [BUG] Zephyr Build Error - Dependency Loop #461,
to remove the depends on FULL_LIBCPP_SUPPORTED from the erpc Kconfig file.
