### PR TITLE
serial: add extended Linux baud rate support

### DIFF
--- a/erpc_c/port/erpc_serial.cpp
+++ b/erpc_c/port/erpc_serial.cpp
@@ -103,11 +103,23 @@ int serial_setup(int fd, speed_t speed)
         case 9600:
             speed = B9600;
             break;
+        case 19200:
+            speed = B19200;
+            break;
         case 38400:
             speed = B38400;
             break;
         case 115200:
             speed = B115200;
+            break;
+        case 230400:
+            speed = B230400; 
+            break;
+        case 460800:
+            speed = B460800;
+            break;
+        case 921600:
+            speed = B921600;
             break;
         case 57600:
         default:


### PR DESCRIPTION
# Pull request

## Choose Correct

- [ ] bug
- [x] feature

## Describe the pull request

This PR extends Linux `serial_setup()` to support additional standard baud rates:
- 19200
- 230400
- 460800
- 921600
Unsupported baud rates now gracefully fallback to 57600 instead of failing.
This improves compatibility with higher-speed serial devices commonly used in embedded and industrial systems.


## To Reproduce

1. Open a serial device with a baud rate of 230400, 460800, or 921600.
2. Call serial_setup() with the new baud rate.

## Expected behavior

- The serial device should initialize successfully at the requested baud rate.
- For unsupported baud rates, it will fallback to 57600 instead of erroring out.


## Screenshots

N/A


## Desktop (please complete the following information):

- OS : ubuntu 22.04
- eRPC Version : v1.14.0

## Steps you didn't forgot to do

- [x] I checked if other PR isn't solving this issue.
- [x] I read Contribution details and did appropriate actions.
- [x] PR code is tested.
- [x] PR code is formatted.
- [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context
<!--
Add any other context about the problem here.
-->
