### PR TITLE
fix: parse IDL file in erpcsniffer

### DIFF
--- a/erpcsniffer/src/erpcsniffer.cpp
+++ b/erpcsniffer/src/erpcsniffer.cpp
@@ -331,6 +331,7 @@ public:
 
             // Parse and build definition model.
             InterfaceDefinition def;
+            def.parse(m_ErpcFile);
 
             // Check for duplicate function IDs
             UniqueIdChecker uniqueIdCheck;


### PR DESCRIPTION
# Pull request

## Choose Correct

* [x] bug
* [ ] feature

## Describe the pull request

This PR restores IDL parsing in `erpcsniffer`.

`erpcsniffer` accepts an `.erpc` file and uses the parsed IDL model to decode captured eRPC messages into interface names, function names, prototypes, and parameter values.

Currently, `erpcsniffer` creates an empty `InterfaceDefinition` and passes it to `Sniffer` without parsing the input `.erpc` file first. As a result, it can receive and partially decode a message, but cannot resolve the interface id from the captured message.

This PR calls `def.parse(m_ErpcFile)` after creating `InterfaceDefinition def` and before running `UniqueIdChecker`.

## To Reproduce

Using the `hello_world` example:

1. Build `erpcsniffer` and the `hello_world` example.
2. Run `erpcsniffer`:

```bash
./Release/Linux/erpcsniffer/erpcsniffer \
  -t tcp \
  -h localhost \
  -p 8811 \
  -q 1 \
  -v \
  -o /tmp/hello_world_erpcsniffer.txt \
  examples/hello_world/hello_world.erpc
```

3. Run the `hello_world` client in another terminal:

```bash
./build/examples/hello_world/client
```

Before this fix, `erpcsniffer` receives the message but cannot resolve the interface:

```text
receiving messages
message received
1. 'Request' message (id: 0) ... Sequence number 1.
Unrecognized interface's id:1
```

## Expected behavior

`erpcsniffer` should parse the provided `.erpc` file and use it to decode the captured message.

After this fix, the same `hello_world` request is decoded as:

```text
receiving messages
message received
1. 'Request' message (id: 0) ... Sequence number 1.
Group name:
Interface name:TextService id:1
Function name:printText id:1 prototype: bool printText(string text);
  Param 'text':
    string value: Hello world!
```

## Screenshots

N/A

## Desktop (please complete the following information):

* OS<!--[e.g. iOS]-->: Ubuntu Linux
* eRPC Version<!--[e.g. v1.9.0]-->: main branch / current checkout

## Steps you didn't forgot to do

* [x] I checked if other PR isn't solving this issue.
* [x] I read Contribution details and did appropriate actions.
* [x] PR code is tested.
* [x] PR code is formatted.
* [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context

The IDL parsing call existed in commit `[9258f58](https://github.com/EmbeddedRPC/erpc/commit/9258f580f8b9dc4b440c667db96aa461baadc50a)`:

```cpp
InterfaceDefinition def;
uint16_t idlCrc16 = def.parse(m_ErpcFile);
```

It was removed in commit `[ffee61e](https://github.com/EmbeddedRPC/erpc/commit/ffee61e0e699062ff08a7c636f30aefb05acce44)` (`eRPC updates 12/2017 2`) while the CRC initialization logic was changed.

That change removed the old `idlCrc16` variable and the `def.parse(m_ErpcFile)` call together. The later CRC code uses `def.hasProgramSymbol()` and `def.getIdlCrc16()`, but because the input `.erpc` file is no longer parsed, the `InterfaceDefinition` remains empty.

This appears to be an accidental regression from the CRC logic change: the previous `def.parse()` call was used both to parse the IDL model and to obtain the IDL CRC value. The CRC handling was changed, but the IDL parsing side effect still needs to happen.

This PR restores only the IDL parsing step. It does not change transport setup, message format, codec behavior, or CRC configuration logic.
