### PR TITLE
Fix ERPC_MESSAGE_LOGGING build errors

### DIFF
--- a/erpc_c/infra/erpc_arbitrated_client_manager.cpp
+++ b/erpc_c/infra/erpc_arbitrated_client_manager.cpp
@@ -66,7 +66,7 @@ void ArbitratedClientManager::performClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
     if (request.getCodec()->isStatusOk() == true)
     {
-        err = logMessage(request.getCodec()->getBuffer());
+        err = logMessage(&request.getCodec()->getBufferRef());
         request.getCodec()->updateStatus(err);
     }
 #endif
@@ -95,7 +95,7 @@ void ArbitratedClientManager::performClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
         if (request.getCodec()->isStatusOk() == true)
         {
-            err = logMessage(request.getCodec()->getBuffer());
+            err = logMessage(&request.getCodec()->getBufferRef());
             request.getCodec()->updateStatus(err);
         }
 #endif

--- a/erpc_c/infra/erpc_client_manager.cpp
+++ b/erpc_c/infra/erpc_client_manager.cpp
@@ -71,7 +71,7 @@ void ClientManager::performClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
     if (request.getCodec()->isStatusOk() == true)
     {
-        err = logMessage(request.getCodec()->getBuffer());
+        err = logMessage(&request.getCodec()->getBufferRef());
         request.getCodec()->updateStatus(err);
     }
 #endif
@@ -96,7 +96,7 @@ void ClientManager::performClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
         if (request.getCodec()->isStatusOk() == true)
         {
-            err = logMessage(request.getCodec()->getBuffer());
+            err = logMessage(&request.getCodec()->getBufferRef());
             request.getCodec()->updateStatus(err);
         }
 #endif
@@ -119,7 +119,7 @@ void ClientManager::performNestedClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
     if (request.getCodec()->isStatusOk() == true)
     {
-        err = logMessage(request.getCodec()->getBuffer());
+        err = logMessage(&request.getCodec()->getBufferRef());
         request.getCodec()->updateStatus(err);
     }
 #endif
@@ -145,7 +145,7 @@ void ClientManager::performNestedClientRequest(RequestContext &request)
 #if ERPC_MESSAGE_LOGGING
         if (request.getCodec()->isStatusOk() == true)
         {
-            err = logMessage(request.getCodec()->getBuffer());
+            err = logMessage(&request.getCodec()->getBufferRef());
             request.getCodec()->updateStatus(err);
         }
 #endif

--- a/erpc_c/infra/erpc_simple_server.cpp
+++ b/erpc_c/infra/erpc_simple_server.cpp
@@ -155,7 +155,7 @@ erpc_status_t SimpleServer::runInternalEnd(Codec *codec, message_type_t msgType,
         if (msgType != message_type_t::kOnewayMessage)
         {
 #if ERPC_MESSAGE_LOGGING
-            err = logMessage(codec->getBuffer());
+            err = logMessage(&codec->getBufferRef());
             if (err == kErpcStatus_Success)
             {
 #endif


### PR DESCRIPTION
# Pull request

## Choose Correct

* [x] bug
* [ ] feature

## Describe the pull request

Fix compilation failures when `ERPC_MESSAGE_LOGGING` is enabled.

The message logging path currently passes `Codec::getBuffer()` to `logMessage()`, but `logMessage()` expects a `MessageBuffer *` while `Codec::getBuffer()` returns a `MessageBuffer` value.

This PR changes the logging path to pass the address of `Codec::getBufferRef()` instead. This uses the codec-owned message buffer and matches the existing transport send/receive paths, which already use `&request.getCodec()->getBufferRef()` or `&codec->getBufferRef()`.

This fixes issue #436.

The relevant history appears to be PR #324 / commit `4c120bb` (`improved codec function to use reference instead of address`). That change introduced/reference-aligned the codec buffer access path, but the `ERPC_MESSAGE_LOGGING` call sites still used `getBuffer()`. `v1.10.0` predates that commit, while `v1.11.0` and later include it. Issue #436 confirms the failure on `v1.13.0`.

This PR is intentionally limited to the compile-time `MessageBuffer` / `MessageBuffer *` mismatch. It does not change message logger transport initialization, CRC setup, `erpcsniffer` behavior, or example behavior.

## To Reproduce

Enable `ERPC_MESSAGE_LOGGING` and build the C/C++ runtime.

For example, set:

```c
#define ERPC_MESSAGE_LOGGING 1
```

Then build the project.

Before this fix, compilation fails at message logging call sites similar to:

```text
erpc_c/infra/erpc_client_manager.cpp: error: cannot convert 'erpc::MessageBuffer' to 'erpc::MessageBuffer *'
    err = logMessage(request.getCodec()->getBuffer());
```

The same mismatch exists in the client, arbitrated client, and simple server logging paths.

## Expected behavior

`ERPC_MESSAGE_LOGGING` should compile successfully.

The logger should receive a pointer to the codec-owned `MessageBuffer`, not a copied `MessageBuffer` value. This should be consistent with the existing transport send/receive paths.

## Screenshots

Not applicable.

## Desktop (please complete the following information):

* OS: Linux
* eRPC Version: main branch; issue reproduced on v1.13.0 according to #436

## Steps you didn't forgot to do

* [x] I checked if other PR isn't solving this issue.
* [x] I read Contribution details and did appropriate actions.
* [x] PR code is tested.
* [x] PR code is formatted.
* [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context

This PR only fixes the compile-time mismatch reported in #436.

A complete runtime validation of `ERPC_MESSAGE_LOGGING` with `erpcsniffer` may still require additional checks depending on the selected logger transport, such as transport initialization and CRC setup. Those runtime concerns are intentionally left out of this PR to keep the fix focused on the build failure.
