### PR TITLE
fix: initialize CRC for message logger transports

### DIFF
--- a/erpc_c/setup/erpc_arbitrated_client_setup.cpp
+++ b/erpc_c/setup/erpc_arbitrated_client_setup.cpp
@@ -199,9 +199,17 @@ bool erpc_arbitrated_client_add_message_logger(erpc_client_t client, erpc_transp
 {
     erpc_assert(client != NULL);
 
-    ArbitratedClientManager *clientManager = reinterpret_cast<ArbitratedClientManager *>(client);
+    if (transport == NULL)
+    {
+        return false;
+    }
 
-    return clientManager->addMessageLogger(reinterpret_cast<Transport *>(transport));
+    ArbitratedClientManager *clientManager = reinterpret_cast<ArbitratedClientManager *>(client);
+    Transport *loggerTransport = reinterpret_cast<Transport *>(transport);
+
+    loggerTransport->setCrc16(clientManager->getArbitrator()->getSharedTransport()->getCrc16());
+
+    return clientManager->addMessageLogger(loggerTransport);
 }
 #endif
 

--- a/erpc_c/setup/erpc_client_setup.cpp
+++ b/erpc_c/setup/erpc_client_setup.cpp
@@ -158,9 +158,17 @@ bool erpc_client_add_message_logger(erpc_client_t client, erpc_transport_t trans
 {
     erpc_assert(client != NULL);
 
-    ClientManager *clientManager = reinterpret_cast<ClientManager *>(client);
+    if (transport == NULL)
+    {
+        return false;
+    }
 
-    return clientManager->addMessageLogger(reinterpret_cast<Transport *>(transport));
+    ClientManager *clientManager = reinterpret_cast<ClientManager *>(client);
+    Transport *loggerTransport = reinterpret_cast<Transport *>(transport);
+
+    loggerTransport->setCrc16(clientManager->getTransport()->getCrc16());
+
+    return clientManager->addMessageLogger(loggerTransport);
 }
 #endif
 

--- a/erpc_c/setup/erpc_server_setup.cpp
+++ b/erpc_c/setup/erpc_server_setup.cpp
@@ -182,9 +182,17 @@ bool erpc_server_add_message_logger(erpc_server_t server, erpc_transport_t trans
 {
     erpc_assert(server != NULL);
 
-    SimpleServer *simpleServer = reinterpret_cast<SimpleServer *>(server);
+    if (transport == NULL)
+    {
+        return false;
+    }
 
-    return simpleServer->addMessageLogger(reinterpret_cast<Transport *>(transport));
+    SimpleServer *simpleServer = reinterpret_cast<SimpleServer *>(server);
+    Transport *loggerTransport = reinterpret_cast<Transport *>(transport);
+
+    loggerTransport->setCrc16(simpleServer->getTransport()->getCrc16());
+
+    return simpleServer->addMessageLogger(loggerTransport);
 }
 #endif
 


### PR DESCRIPTION
# Pull request

## Choose Correct

* [x] bug
* [ ] feature

## Describe the pull request

Initialize the CRC implementation for message logger transports before registering them with the client, server, or arbitrated client.

The normal client/server setup path assigns a `Crc16` object to the active transport during initialization. However, the `erpc_*_add_message_logger()` setup APIs only registered the logger transport and did not assign a CRC implementation to it.

This breaks message logging when the logger transport is a framed transport, such as TCP or serial, because framed transports require a valid `Crc16` object before `send()`.

This PR reuses the CRC implementation already configured on the active client/server transport for the logger transport. The logger transport does not own the CRC object; it only references the same CRC implementation used by the active transport.

This PR is intentionally limited to logger transport initialization. It does not change the `MessageBuffer` / `MessageBuffer *` compile-time fix covered by PR #480, and it does not change example behavior.

## To Reproduce

Use `ERPC_MESSAGE_LOGGING` with a framed logger transport.

One example setup is:

1. Enable `ERPC_MESSAGE_LOGGING`.
2. Build the runtime with the message logging compile fix from PR #480 or an equivalent local fix.
3. Initialize the normal client/server transport.
4. Initialize a second TCP or serial transport for message logging.
5. Register the second transport with `erpc_client_add_message_logger()`, `erpc_server_add_message_logger()`, or `erpc_arbitrated_client_add_message_logger()`.
6. Run an RPC call and send the logged message to `erpcsniffer`.

Before this change, the logger transport can fail during `send()` because the framed transport has no CRC implementation assigned.

## Expected behavior

A framed logger transport should be initialized consistently with the active client/server transport.

After registering a logger transport through the C setup API, message logging should be able to send framed messages without hitting an uninitialized CRC assertion.

## Screenshots

Not applicable.

## Desktop (please complete the following information):

* OS: Linux
* eRPC Version: main branch

## Steps you didn't forgot to do

* [x] I checked if other PR isn't solving this issue.
* [x] I read Contribution details and did appropriate actions.
* [x] PR code is tested.
* [x] PR code is formatted.
* [x] Allow edits from maintainers pull request option is set (recommended).

## Additional context

### History / regression scope

This is not a regression from a currently known later commit.

Message logging and the eRPC sniffer were introduced in commit [`f67826a` ](https://github.com/EmbeddedRPC/erpc/commit/f67826a6923da3065c279a6e46af25cb387c077c)(`eRPC updates`), which added support for sending logged eRPC messages to the sniffer tool. In that implementation, the normal client/server setup path assigned a `Crc16` object to the active transport, but the message logger registration path only stored the logger transport and did not assign a CRC implementation to it.

That means there is no known earlier commit where the C setup API path worked correctly with a framed logger transport such as TCP or serial. Before message logging was introduced, this functionality was not available; after it was introduced, framed logger transports could still be left without the CRC object required by `FramedTransport::send()`.

This PR fixes that initialization gap by assigning the logger transport the same CRC implementation already configured on the active client/server transport. The logger transport does not own the CRC object.

### Relation to PR #480

PR #480 fixes the compile-time `MessageBuffer` / `MessageBuffer *` mismatch when `ERPC_MESSAGE_LOGGING` is enabled.

This PR addresses the next runtime issue: framed logger transports registered through the C setup API do not have a CRC implementation assigned.
